### PR TITLE
#77 Supports GCP module using a dictionary containing service account info in Google format.

### DIFF
--- a/cliboa/scenario/extract/gcp.py
+++ b/cliboa/scenario/extract/gcp.py
@@ -25,7 +25,7 @@ from cliboa.scenario.gcp import BaseBigQuery, BaseFirestore, BaseGcs
 from cliboa.scenario.validator import EssentialParameters
 from cliboa.util.cache import ObjectStore
 from cliboa.util.exception import InvalidParameter
-from cliboa.util.gcp import BigQuery, Gcs, ServiceAccount
+from cliboa.util.gcp import BigQuery, Firestore, Gcs, ServiceAccount
 from cliboa.util.string import StringUtil
 
 
@@ -200,7 +200,7 @@ class BigQueryReadCache(BaseBigQuery):
             dialect="standard",
             location=self._location,
             project_id=self._project_id,
-            credentials=self._auth(),
+            credentials=ServiceAccount.auth(self._credentials),
         )
         ObjectStore.put(self._key, df)
 
@@ -239,10 +239,10 @@ class BigQueryFileDownload(BaseBigQuery):
 
         os.makedirs(self._dest_dir, exist_ok=True)
 
-        gbq_client = self._bigquery_client()
+        gbq_client = BigQuery.get_bigquery_client(self._credentials)
         gbq_ref = gbq_client.dataset(self._dataset).table(self._tblname)
 
-        gcs_client = self._gcs_client()
+        gcs_client = Gcs.get_gcs_client(self._credentials)
         gcs_bucket = gcs_client.get_bucket(self._bucket)
 
         ymd_hms = datetime.now().strftime("%Y%m%d%H%M%S%f")
@@ -306,7 +306,7 @@ class GcsDownload(BaseGcs):
         valid = EssentialParameters(self.__class__.__name__, [self._src_pattern])
         valid()
 
-        client = self._gcs_client()
+        client = Gcs.get_gcs_client(self._credentials)
         bucket = client.get_bucket(self._bucket)
         dl_files = []
         for blob in bucket.list_blobs(prefix=self._prefix, delimiter=self._delimiter):
@@ -368,7 +368,7 @@ class FirestoreDownloadDocument(BaseFirestore):
         )
         valid()
 
-        firestore_client = self._firestore_client()
+        firestore_client = Firestore.get_firestore_client(self._credentials)
         ref = firestore_client.document(self._collection, self._document)
         doc = ref.get()
 

--- a/cliboa/scenario/gcp.py
+++ b/cliboa/scenario/gcp.py
@@ -61,7 +61,7 @@ class BaseGcp(BaseStep):
     def _gcs_client(self):
         """
         @deprecated
-        use Gcs.get_client() in util.gcp
+        use Gcs.get_gcs_client() in util.gcp
         """
         if self._credentials:
             return storage.Client.from_service_account_json(self._credentials)
@@ -69,6 +69,10 @@ class BaseGcp(BaseStep):
             return storage.Client()
 
     def _firestore_client(self):
+        """
+        @deprecated
+        use Firestore.get_firestore_client() in util.gcp
+        """
         if self._credentials:
             return firestore.Client.from_service_account_json(self._credentials)
         else:

--- a/cliboa/scenario/load/gcp.py
+++ b/cliboa/scenario/load/gcp.py
@@ -22,7 +22,7 @@ from cliboa.core.validator import EssentialParameters
 from cliboa.scenario.gcp import BaseBigQuery, BaseFirestore, BaseGcs
 from cliboa.scenario.load.file import FileWrite
 from cliboa.util.exception import FileNotFound, InvalidFileCount, InvalidFormat
-from cliboa.util.gcp import BigQuery, Gcs, ServiceAccount
+from cliboa.util.gcp import Firestore, Gcs, ServiceAccount
 
 
 class BigQueryWrite(BaseBigQuery, FileWrite):
@@ -212,7 +212,7 @@ class BigQueryCreate(BaseBigQuery):
                         if_exists=if_exists,
                         table_schema=self._table_schema,
                         location=self._location,
-                        credentials=self._auth(),
+                        credentials=ServiceAccount.auth(self._credentials),
                     )
                     cache_list.clear()
                     inserts = True
@@ -231,7 +231,7 @@ class BigQueryCreate(BaseBigQuery):
                     if_exists=if_exists,
                     table_schema=self._table_schema,
                     location=self._location,
-                    credentials=self._auth(),
+                    credentials=ServiceAccount.auth(self._credentials),
                 )
         self._s.remove()
 
@@ -289,7 +289,7 @@ class GcsFileUpload(BaseGcs):
         )
         valid()
 
-        gcs_client = self._gcs_client()
+        gcs_client = Gcs.get_gcs_client(self._credentials)
         bucket = gcs_client.get_bucket(self._bucket)
         files = super().get_target_files(self._src_dir, self._src_pattern)
         self._logger.info("Upload files %s" % files)
@@ -328,7 +328,7 @@ class GcsUpload(BaseGcs):
         )
         valid()
 
-        gcs_client = self._gcs_client()
+        gcs_client = Gcs.get_gcs_client(self._credentials)
         bucket = gcs_client.get_bucket(self._bucket)
         files = super().get_target_files(self._src_dir, self._src_pattern)
         self._logger.info("Upload files %s" % files)
@@ -418,7 +418,7 @@ class CsvReadBigQueryCreate(BaseBigQuery, FileWrite):
             if_exists=if_exists,
             table_schema=self._table_schema,
             location=self._location,
-            credentials=self._auth(),
+            credentials=ServiceAccount.auth(self._credentials),
         )
 
     def __format_insert_data(self, insert_rows):
@@ -474,7 +474,7 @@ class FirestoreDocumentCreate(BaseFirestore):
         if len(files) == 0:
             raise FileNotFound("No files are found.")
 
-        firestore_client = self._firestore_client()
+        firestore_client = Firestore.get_firestore_client(self._credentials)
 
         for file in files:
             with open(file) as f:

--- a/cliboa/util/gcp.py
+++ b/cliboa/util/gcp.py
@@ -11,7 +11,7 @@
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 #
-from google.cloud import bigquery, storage
+from google.cloud import bigquery, firestore, storage
 from google.oauth2 import service_account
 
 from cliboa.util.lisboa_log import LisboaLog
@@ -20,11 +20,19 @@ from cliboa.util.lisboa_log import LisboaLog
 class ServiceAccount(object):
     """
     Service Account api wrapper
+    Creates a Signer instance from a service account .json file path or a dictionary containing service account info in Google format.
+    Args:
+        credentials: gcp service account json
     """
 
     @staticmethod
     def auth(credentials):
-        return service_account.Credentials.from_service_account_file(credentials)
+        if not credentials:
+            return None
+        if isinstance(credentials, dict):
+            return service_account.Credentials.from_service_account_info(credentials)
+        else:
+            return service_account.Credentials.from_service_account_file(credentials)
 
 
 class BigQuery(object):
@@ -41,11 +49,7 @@ class BigQuery(object):
         Args:
            credentials: gcp service account json
         """
-        return (
-            bigquery.Client.from_service_account_json(credentials)
-            if credentials
-            else bigquery.Client()
-        )
+        return bigquery.Client(credentials=ServiceAccount.auth(credentials))
 
     @staticmethod
     def get_extract_job_config(print_header=True):
@@ -88,8 +92,14 @@ class Gcs(object):
 
     @staticmethod
     def get_gcs_client(credentials):
-        return (
-            storage.Client.from_service_account_json(credentials)
-            if credentials
-            else storage.Client()
-        )
+        return storage.Client(credentials=ServiceAccount.auth(credentials))
+
+
+class Firestore(object):
+    """
+    google firestore api wrapper
+    """
+
+    @staticmethod
+    def get_firestore_client(credentials):
+        return firestore.Client(credentials=ServiceAccount.auth(credentials))

--- a/docs/modules/bigquery_file_download.md
+++ b/docs/modules/bigquery_file_download.md
@@ -6,7 +6,7 @@ Execute select query and download result as a csv file. When extract data from G
 |----------|-----------|--------|-------|-------|
 |project_id|GCP project id|Yes|None||
 |location|GCP location|Yes|None||
-|credentials|A file path of credential for GCP authentication|Yes|None||
+|credentials|A service account .json file path or a dictionary containing service account info in Google format|Yes|None||
 |dataset|BigQuery dataset|Yes|None||
 |tblname|BigQuery table name to insert|Yes|None||
 |bucket|Bucket of GCS to save a temporal data|Yes|None||

--- a/docs/modules/bigquery_write.md
+++ b/docs/modules/bigquery_write.md
@@ -9,7 +9,7 @@ Read content from csv files and insert them into a bigquery table.
 |has_header|Csv has header or not. Specify either True or False|No|True||
 |project_id|GCP project id|Yes|None||
 |location|GCP location|Yes|None||
-|credentials|a file path of credential for GCP authentication|Yes|None||
+|credentials|A service account .json file path or a dictionary containing service account info in Google format|Yes|None||
 |dataset|BigQuery dataset|Yes|None||
 |tblname|BigQuery table name to insert|Yes|None||
 |replace|BigQuery insert mode. Specify either True or False|No|True||

--- a/docs/modules/firestore_document_create.md
+++ b/docs/modules/firestore_document_create.md
@@ -7,7 +7,7 @@ Document names will be the same with the file names.
 |----------|-----------|--------|-------|-------|
 |project_id|GCP project id|Yes|None||
 |location|GCP location|Yes|None||
-|credentials|A file path of credential for GCP authentication|Yes|None||
+|credentials|A service account .json file path or a dictionary containing service account info in Google format|Yes|None||
 |collection|Collection name|Yes|None||
 |src_dir|Directory that files exists|Yes|None||
 |src_pattern|File pattern of source. Regexp is available|Yes|None||

--- a/docs/modules/firestore_document_download.md
+++ b/docs/modules/firestore_document_download.md
@@ -6,7 +6,7 @@ Download a document from Firestore.
 |----------|-----------|--------|-------|-------|
 |project_id|GCP project id|Yes|None||
 |location|GCP location|Yes|None||
-|credentials|A file path of credential for GCP authentication|Yes|None||
+|credentials|A service account .json file path or a dictionary containing service account info in Google format|Yes|None||
 |collection|Collection name|Yes|None||
 |document|Document name|Yes|None||
 |dest_dir|Destination directory to download the file|Yes|None||

--- a/docs/modules/gcs_download.md
+++ b/docs/modules/gcs_download.md
@@ -6,7 +6,7 @@ Download files from GCS.
 |----------|-----------|--------|-------|-------|
 |project_id|GCP project id|Yes|None||
 |location|GCP location|Yes|None||
-|credentials|A file path of credential for GCP authentication|Yes|None||
+|credentials|A service account .json file path or a dictionary containing service account info in Google format|Yes|None||
 |bucket|GCS bucket name|Yes|None||
 |prefix|Folder prefix used to filter blobs|No|None||
 |delimiter|Delimiter, used with prefix to emulate hierarchy|No|None||

--- a/docs/modules/gcs_upload.md
+++ b/docs/modules/gcs_upload.md
@@ -6,7 +6,7 @@ Upload files to GCS.
 |----------|-----------|--------|-------|-------|
 |project_id|GCP project id|Yes|None||
 |location|GCP location|Yes|None||
-|credentials|A file path of credential for GCP authentication|Yes|None||
+|credentials|A service account .json file path or a dictionary containing service account info in Google format|Yes|None||
 |bucket|GCS bucket name|Yes|None||
 |src_dir|Directory of source to upload|Yes|None||
 |src_pattern|File pattern of source to upload. Regexp is available|Yes|None||

--- a/tests/util/test_gcp.py
+++ b/tests/util/test_gcp.py
@@ -23,7 +23,7 @@ from cliboa.util.gcp import BigQuery, Gcs, ServiceAccount
 class TestServiceAccount(TestCase):
     @pytest.mark.skip(reason="service account connection is neccesary")
     def test_auth_no_credentials(self):
-        assert ServiceAccount.auth(None) == ""
+        assert ServiceAccount.auth(None) is None
 
 
 class TestBigQuery(TestCase):


### PR DESCRIPTION
Fixed GCP modules to support service account .json file path or a dictionary containing service account info in Google format.

The following is an example of specifying a dictionary.

```
scenario:
  - step:
    class: GcsDownload
    arguments:
      project_id:
      location:
      credentials: {
        "type": "service_account",
        "project_id": "xxxxxxxxx",
        ...
      }
      bucket:
      prefix:
      src_pattern:
      dest_dir:
```

