### PR TITLE
cliboadmin init was failed #131

### DIFF
--- a/cliboa/cli/cliboadmin.py
+++ b/cliboa/cli/cliboadmin.py
@@ -15,8 +15,8 @@
 #
 
 import argparse
+import cliboa
 import os
-import site
 import sys
 from importlib import import_module
 from shutil import copyfile
@@ -75,12 +75,7 @@ class CliboAdmin(object):
         """
         create essential files
         """
-        cliboa_install_paths = site.getsitepackages()
-        cliboa_install_path = (
-            cliboa_install_paths[0]
-            if os.path.exists(os.path.join(cliboa_install_paths[0], "cliboa"))
-            else cliboa_install_paths[1]
-        )
+        cliboa_install_path = os.path.dirname(cliboa.__path__[0])
 
         run_cmd_path = os.path.join(
             cliboa_install_path, "cliboa", "template", "bin", "clibomanager.py"


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/cliboa/.local/bin/cliboadmin", line 8, in <module>
    sys.exit(main())
  File "/home/cliboa/.local/lib/python3.7/site-packages/cliboa/cli/cliboadmin.py", line 181, in main
    admin.main()
  File "/home/cliboa/.local/lib/python3.7/site-packages/cliboa/cli/cliboadmin.py", line 42, in main
    self._init_project(self._args.dir_name)
  File "/home/cliboa/.local/lib/python3.7/site-packages/cliboa/cli/cliboadmin.py", line 57, in _init_project
    self._create_ess_files(ini_dir)
  File "/home/cliboa/.local/lib/python3.7/site-packages/cliboa/cli/cliboadmin.py", line 82, in _create_ess_files
    else cliboa_install_paths[1]
IndexError: list index out of range
```

I think site.getsitepackages() only looks for global site-packages.
However, it can also be installed in the user's site-packages.