### PR TITLE
[8/6〆]add git-secrets on security.yaml

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -21,4 +21,4 @@ jobs:
           git secrets --add "password\s*=\s*\".+\""
           git secrets --add --allowed --literal "password=\"dymmy|dummypass\""
       - name: check secrets
-        run: git secrets -r .
+        run: git secrets --scan -r .

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -21,8 +21,12 @@ jobs:
 
           # add other secrets
           git secrets --add "user\s*=\s*\".+\""
-          git secrets --add --allowed --literal "user=\"dummy|dummyuser\""
+          git secrets --add --allowed "user\s*=\"dummy.*\""
           git secrets --add "password\s*=\s*\".+\""
-          git secrets --add --allowed --literal "password=\"dummy|dummypass\""
+          git secrets --add --allowed "password\s*=\"dummy.*\""
       - name: check secrets
-        run: git secrets --scan -r .
+        run: |
+          # list rules
+          git secrets --list
+          # check
+          git secrets --scan -r .

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: install git-secrets
         run: |
           mkdir git-secrets
-          git clone https://github.com/awslabs/git-secrets.git
+          git clone https://github.com/awslabs/git-secrets.git git-secrets
           cd git-secrets
           make install
       - name: setup git-secrets

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -9,6 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: install git-secrets
         run: |
+          mkdir git-secrets
           git clone https://github.com/awslabs/git-secrets.git
           cd git-secrets
           make install

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -9,6 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: install git-secrets
         run: |
+          cd ~/
           mkdir git-secrets
           git clone https://github.com/awslabs/git-secrets.git git-secrets
           cd git-secrets

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,24 @@
+name: cliboa-security
+
+on: [push]
+
+jobs:
+  git_secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install git-secrets
+        run: |
+          git clone https://github.com/awslabs/git-secrets.git
+          cd git-secrets
+          make install
+      - name: setup git-secrets
+        run: |
+          git secrets --install
+          # add aws secrets
+          git secrets --register-aws
+          # add other secrets
+          git secrets --add "password\s*=\s*\".+\""
+          git secrets --add --allowed --literal "password=\"dymmy|dummypass\""
+      - name: check secrets
+        run: git secrets -r .

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -15,10 +15,14 @@ jobs:
       - name: setup git-secrets
         run: |
           git secrets --install
+
           # add aws secrets
           git secrets --register-aws
+
           # add other secrets
+          git secrets --add "user\s*=\s*\".+\""
+          git secrets --add --allowed --literal "user=\"dummy|dummyuser\""
           git secrets --add "password\s*=\s*\".+\""
-          git secrets --add --allowed --literal "password=\"dymmy|dummypass\""
+          git secrets --add --allowed --literal "password=\"dummy|dummypass\""
       - name: check secrets
         run: git secrets --scan -r .

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -20,8 +20,6 @@ jobs:
           git secrets --register-aws
 
           # add other secrets
-          git secrets --add "user\s*=\s*\".+\""
-          git secrets --add --allowed "user\s*=\"dummy.*\""
           git secrets --add "password\s*=\s*\".+\""
           git secrets --add --allowed "password\s*=\"dummy.*\""
       - name: check secrets

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -9,11 +9,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: install git-secrets
         run: |
-          cd ~/
-          mkdir git-secrets
           git clone https://github.com/awslabs/git-secrets.git git-secrets
           cd git-secrets
-          make install
+          sudo make install
       - name: setup git-secrets
         run: |
           git secrets --install

--- a/cliboa/test/adapter/test_rdbms.py
+++ b/cliboa/test/adapter/test_rdbms.py
@@ -14,7 +14,7 @@ class TestRdbms(BaseCliboaTest):
         with ExitStack() as stack:
             stack.enter_context(patch("cliboa.adapter.mysql.pymysql"))
             with MysqlAdaptor(
-                host="dummy", user="test", password="password", dbname="test"
+                host="dummy", user="test", password="dummypassword", dbname="test"
             ):
                 pass
 
@@ -26,7 +26,7 @@ class TestRdbms(BaseCliboaTest):
             stack.enter_context(patch("cliboa.adapter.mysql.pymysql"))
             try:
                 with MysqlAdaptor(
-                    host="dummy", user="test", password="password", dbname="test"
+                    host="dummy", user="test", password="dummypassword", dbname="test"
                 ):
                     raise Exception("Error occurred")
             except Exception:

--- a/cliboa/test/util/test_sftp.py
+++ b/cliboa/test/util/test_sftp.py
@@ -17,7 +17,7 @@ class TestSftp(BaseCliboaTest):
             mock_func.return_value = ["test.txt"]
             stack.enter_context(patch("paramiko.SSHClient.connect"))
             stack.enter_context(patch("paramiko.SSHClient.open_sftp"))
-            sftp = Sftp(host="test", user="admin", password="pass")
+            sftp = Sftp(host="test", user="admin", password="dummypass")
             sftp.list_files(None, None, None)
             mock_func.assert_called_once()
 
@@ -30,7 +30,7 @@ class TestSftp(BaseCliboaTest):
             mock_func = stack.enter_context(patch("cliboa.util.sftp.clear_file_func"))
             stack.enter_context(patch("paramiko.SSHClient.connect"))
             stack.enter_context(patch("paramiko.SSHClient.open_sftp"))
-            sftp = Sftp(host="test", user="admin", password="pass")
+            sftp = Sftp(host="test", user="admin", password="dummypass")
             sftp.clear_files(None, None)
             mock_func.assert_called_once()
 

--- a/cliboa/test/util/test_sftp.py
+++ b/cliboa/test/util/test_sftp.py
@@ -17,7 +17,7 @@ class TestSftp(BaseCliboaTest):
             mock_func.return_value = ["test.txt"]
             stack.enter_context(patch("paramiko.SSHClient.connect"))
             stack.enter_context(patch("paramiko.SSHClient.open_sftp"))
-            sftp = Sftp(host="test", user="admin", password="dummypass")
+            sftp = Sftp(host="test", user="dummyadmin", password="dummypass")
             sftp.list_files(None, None, None)
             mock_func.assert_called_once()
 

--- a/cliboa/test/util/test_sftp.py
+++ b/cliboa/test/util/test_sftp.py
@@ -45,7 +45,7 @@ class TestSftp(BaseCliboaTest):
             )
             stack.enter_context(patch("paramiko.SSHClient.connect"))
             stack.enter_context(patch("paramiko.SSHClient.open_sftp"))
-            sftp = Sftp(host="test", user="admin", password="pass")
+            sftp = Sftp(host="test", user="admin", password="dummypass")
             sftp.remove_specific_file(None, None)
             mock_func.assert_called_once()
 
@@ -60,7 +60,7 @@ class TestSftp(BaseCliboaTest):
             )
             stack.enter_context(patch("paramiko.SSHClient.connect"))
             stack.enter_context(patch("paramiko.SSHClient.open_sftp"))
-            sftp = Sftp(host="test", user="admin", password="pass")
+            sftp = Sftp(host="test", user="admin", password="dummypass")
             sftp.get_specific_file(None, None)
             mock_func.assert_called_once()
 
@@ -73,6 +73,6 @@ class TestSftp(BaseCliboaTest):
             mock_func = stack.enter_context(patch("cliboa.util.sftp.put_file_func"))
             stack.enter_context(patch("paramiko.SSHClient.connect"))
             stack.enter_context(patch("paramiko.SSHClient.open_sftp"))
-            sftp = Sftp(host="test", user="admin", password="pass")
+            sftp = Sftp(host="test", user="admin", password="dummypass")
             sftp.put_file(None, None)
             mock_func.assert_called_once()


### PR DESCRIPTION
## Brief ##

git-secretsによる機密情報チェックをGitHubActionsのCIパイプラインに追加しました。
チェック内容はAWSの機密情報と、password=の文字列程度にしています。

## Points to Check ##
* GitHubActionsの内容
* git secretsが失敗した時のログ https://github.com/BrainPad/cliboa/runs/3237622461?check_suite_focus=true

### Test ###
Confirmed

（Write content to confirm / Reason why not necessary）


### Review Limit ###
* `Write review limit on pull request title.`
