### PR TITLE
Fix message typo

### DIFF
--- a/cliboa/cli/cliboadmin.py
+++ b/cliboa/cli/cliboadmin.py
@@ -48,7 +48,7 @@ class CliboAdmin(object):
             )
         elif self._args.option == "create":
             self._create_new_project(self._args.dir_name)
-            print("Adding a new project '" + self._args.dir_name + "' was successfule.")
+            print("Adding a new project '" + self._args.dir_name + "' was successful.")
 
     def _init_project(self, ini_dir):
         """


### PR DESCRIPTION
## Brief ##

Fixed a typo in the message displayed when a project is successfully created. (successfule to successful)

## Points to Check ##
* Correctness of the modified word

### Test ###
Not necessary

This change has no effect on behavior.