### PR TITLE
Replace Panda with Big Query

### DIFF
--- a/cliboa/scenario/extract/gcp.py
+++ b/cliboa/scenario/extract/gcp.py
@@ -92,10 +92,10 @@ class BigQueryRead(BaseBigQuery):
         else:
             key_filepath = self._source_path_reader(self._credentials)
 
-        gbq_client = bigquery.Client(
+        gbq_client = BigQuery.get_bigquery_client(
             location=self._location,
             project=self._project_id,
-            credentials=ServiceAccount.auth(key_filepath),
+            credentials=key_filepath
         )
 
         query = "SELECT * FROM %s.%s" % (self._dataset, self._tblname) if self._query is None else self._query
@@ -237,10 +237,10 @@ class BigQueryReadCache(BaseBigQuery):
         else:
             key_filepath = self._source_path_reader(self._credentials)
 
-        gbq_client = bigquery.Client(
+        gbq_client = BigQuery.get_bigquery_client(
             location=self._location,
             project=self._project_id,
-            credentials=ServiceAccount.auth(key_filepath),
+            credentials=key_filepath
         )
 
         df = gbq_client.query(self._get_query()).to_dataframe()

--- a/cliboa/scenario/extract/gcp.py
+++ b/cliboa/scenario/extract/gcp.py
@@ -18,14 +18,13 @@ import re
 import string
 from datetime import datetime
 
-import pandas
 from google.cloud import bigquery
 
 from cliboa.scenario.gcp import BaseBigQuery, BaseFirestore, BaseGcs
 from cliboa.scenario.validator import EssentialParameters
 from cliboa.util.cache import ObjectStore
 from cliboa.util.exception import InvalidParameter
-from cliboa.util.gcp import BigQuery, Firestore, Gcs, ServiceAccount
+from cliboa.util.gcp import BigQuery, Firestore, Gcs
 from cliboa.util.string import StringUtil
 
 
@@ -98,7 +97,8 @@ class BigQueryRead(BaseBigQuery):
             credentials=key_filepath
         )
 
-        query = "SELECT * FROM %s.%s" % (self._dataset, self._tblname) if self._query is None else self._query
+        query = "SELECT * FROM %s.%s" % (self._dataset, self._tblname)
+        if self._query: query = self._query
 
         df = gbq_client.query(query).to_dataframe()
         ObjectStore.put(self._key, df)

--- a/cliboa/scenario/extract/gcp.py
+++ b/cliboa/scenario/extract/gcp.py
@@ -98,7 +98,7 @@ class BigQueryRead(BaseBigQuery):
         )
 
         query = "SELECT * FROM %s.%s" % (self._dataset, self._tblname)
-        if self._query: query = self._query
+        query = self._query if self._query else query
 
         df = gbq_client.query(query).to_dataframe()
         ObjectStore.put(self._key, df)

--- a/cliboa/util/gcp.py
+++ b/cliboa/util/gcp.py
@@ -41,7 +41,7 @@ class BigQuery(object):
     _logger = LisboaLog.get_logger(__name__)
 
     @staticmethod
-    def get_bigquery_client(credentials):
+    def get_bigquery_client(credentials, project=None, location=None):
         """
         get bigquery client object
         Args:
@@ -50,7 +50,9 @@ class BigQuery(object):
         credentials_info = ServiceAccount.auth(credentials)
         return (
             bigquery.Client(
-                credentials=credentials_info, project=credentials_info.project_id
+                credentials=credentials_info,
+                project=project if project else credentials_info.project_id,
+                location=location
             )
             if credentials_info
             else bigquery.Client()


### PR DESCRIPTION
## Brief ##

Issue: https://github.com/BrainPad/cliboa/issues/85

As to BigQueryWrite, it currently loads each _BULK_LINE_CNT rows into a table by using pandas-gbq, however, some issues occur in real use, such as:

Not supported functions by pandas-gbq
For instance, the time-partitioning setting is removed by overwriting a table.
Bulk update may hits the rate limit for updating a table by loading a big CSV file
pandas-gbq depends on slightly heavy libraries (pandas, numpy, etc.), which makes installing slow
I'm sure that it is better to use google-cloud-bigquery and to load a CSV file at once by bigquery.Client.load_table_from_file.

This change is destructive, but I believe in its effectiveness.

See also: https://cloud.google.com/bigquery/docs/pandas-gbq-migration

## Points to Check ##
* 1 Check if Before Change Result and After Change Result is same (BigQueryRead)
* 2 Check if Before Change Result and After Change Result is same (BigQueryReadCache)
* 3 Check if Tests is Passed without changing it

### Test ###
Refactoring change is not necessary

### Review Limit ###
* `Write review limit on pull request title.`
