### PR TITLE
Add Byte Fetch Feature to GCS Download

### DIFF
--- a/cliboa/scenario/extract/gcp.py
+++ b/cliboa/scenario/extract/gcp.py
@@ -11,7 +11,6 @@
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 #
-from io import BytesIO
 import json
 import os
 import random

--- a/docs/modules/gcs_download.md
+++ b/docs/modules/gcs_download.md
@@ -13,8 +13,10 @@ Download files from GCS.
 |delimiter|Delimiter, used with prefix to emulate hierarchy|No|None||
 |src_pattern|File pattern of source to download. Regexp is available|Yes|None||
 |dest_dir|Destination directory to download|No|None||
+|byte_size|Download part of file insted whole file (Integer)|No|None||
 
 # Examples
+
 ```
 - step:
   class: GcsDownload


### PR DESCRIPTION
## Brief ##

- Enable GCSDownload module to download part of file
- Added optional parameter `byte_fetch` to GCSDownload

Issue: https://github.com/BrainPad/cliboa/issues/251

## Points to Check ##
* 1 When `byte-fetch` not specified whole file should be downloaded
* 2 When `byte-fetch` specified only part of file should be downloaded

### Test ###
Confirmed / Confirming / Not necessary

（Write content to confirm / Reason why not necessary）

### Review Limit ###
* `Write review limit on pull request title.`
