### PR TITLE
raise or skip

### DIFF
--- a/cliboa/scenario/extras.py
+++ b/cliboa/scenario/extras.py
@@ -1,0 +1,11 @@
+import logging
+
+
+class ExceptionHandler(object):
+    def __init__(self):
+        super().__init__()
+        self._logger = logging.getLogger(__name__)
+
+    def handle_error(self, *args, **kwargs):
+        # Please implement in a subclass if you would like to do something.
+        self._logger.warning(args)

--- a/cliboa/scenario/transform/file.py
+++ b/cliboa/scenario/transform/file.py
@@ -57,6 +57,7 @@ class FileBaseTransform(BaseStep):
         self._dest_name = None
         self._encoding = "utf-8"
         self._nonfile_error = False
+        self._force_continue = False
 
     def src_dir(self, src_dir):
         self._src_dir = src_dir
@@ -76,6 +77,9 @@ class FileBaseTransform(BaseStep):
 
     def nonfile_error(self, nonfile_error):
         self._nonfile_error = nonfile_error
+
+    def force_continue(self, force_continue):
+        self._force_continue = force_continue
 
     def execute(self, *args):
         pass


### PR DESCRIPTION
複数ファイル処理中にエラーが発生した場合に継続するかエラーにするかを選べるようにしました。
親側だけで対応するのは難しく仕方なくサブクラス内で対応する方針としました。
