### PR TITLE
Allow quote to be specified when reading csv using CsvConvert

### DIFF
--- a/cliboa/scenario/transform/csv.py
+++ b/cliboa/scenario/transform/csv.py
@@ -425,6 +425,7 @@ class CsvConvert(FileBaseTransform, ExceptionHandler):
         self._after_format = None
         self._after_enc = None
         self._after_nl = "LF"
+        self._reader_quote = "QUOTE_NONE"
         self._quote = "QUOTE_MINIMAL"
 
     def headers(self, headers):
@@ -448,6 +449,9 @@ class CsvConvert(FileBaseTransform, ExceptionHandler):
     def after_nl(self, after_nl):
         self._after_nl = after_nl
 
+    def reader_quote(self, reader_quote):
+        self._reader_quote = reader_quote
+
     def quote(self, quote):
         self._quote = quote
 
@@ -470,7 +474,11 @@ class CsvConvert(FileBaseTransform, ExceptionHandler):
         for fi, fo in super().io_files(files, ext=self._after_format):
             try:
                 with open(fi, mode="rt", encoding=self._before_enc) as i:
-                    reader = csv.reader(i, delimiter=Csv.delimiter_convert(self._before_format))
+                    reader = csv.reader(
+                        i,
+                        delimiter=Csv.delimiter_convert(self._before_format),
+                        quoting=Csv.quote_convert(self._reader_quote)
+                    )
                     with open(fo, mode="wt", newline="", encoding=self._after_enc) as o:
                         writer = csv.writer(
                             o,

--- a/docs/modules/csv_convert.md
+++ b/docs/modules/csv_convert.md
@@ -15,6 +15,7 @@ Plural files can be converted at the same time, but format of all files must be 
 |after_format|File extension after converted|No|Same with before_format|"csv" or "tsv"|
 |after_enc|File encoding after converted|Same with before_enc|None||
 |after_nl|New line for converted csv|No|LF|"LF" or "CR" or "CRLF"|
+|reader_quote|quote type for read csv|No|QUOTE_NONE|"QUOTE_ALL" or "QUOTE_MINIMAL" or "QUOTE_NONNUMERIC" or "QUOTE_NONE"|
 |quote|quote type for converted csv|No|QUOTE_MINIMAL|"QUOTE_ALL" or "QUOTE_MINIMAL" or "QUOTE_NONNUMERIC" or "QUOTE_NONE"|
 |nonfile_error|Whether an error is thrown when files are not found in src_dir.|No|False||
 


### PR DESCRIPTION
## Brief ##

Allow quote to be specified when reading csv using CsvConvert

## Points to Check ##
* Is there any discomfort in the corresponding parts and contents?


### Test ###
Confirmed
（Write content to confirm / Reason why not necessary）

### Review Limit ###
* `As soon as possible`
