### PR TITLE
[11/19〆] fix pypi upload script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,4 +39,3 @@ jobs:
         run: |
           # upload to pypi
           sudo python3 tools/script/deploy_to_pypi.py "${{ github.event.inputs.username }}" "${{ github.event.inputs.password }}" "${{ github.event.inputs.is_test }}"
-          cat /tmp/debug

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,3 +39,4 @@ jobs:
         run: |
           # upload to pypi
           sudo python3 tools/script/deploy_to_pypi.py "${{ github.event.inputs.username }}" "${{ github.event.inputs.password }}" "${{ github.event.inputs.is_test }}"
+          cat /tmp/debug

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,10 +31,11 @@ jobs:
       - name: install dependencies
         run: |
           sudo python3 -m pip install twine
-      - name: upload to pypi
+      - name: create pypi package
         run: |
           # create package
           sudo python3 setup.py sdist bdist_wheel
-          
+      - name: upload to pypi
+        run: |
           # upload to pypi
           sudo python3 tools/script/deploy_to_pypi.py "${{ github.event.inputs.username }}" "${{ github.event.inputs.password }}" "${{ github.event.inputs.is_test }}"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def read(filename):
 
 setup(
     name="cliboa",
-    version="2.0.0b0",
+    version="2.0.1b0",
     description="application framework for ETL(ELT) processing",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",

--- a/tools/script/deploy_to_pypi.py
+++ b/tools/script/deploy_to_pypi.py
@@ -4,6 +4,7 @@
 import sys
 
 import pexpect
+import time
 
 args = sys.argv
 pypi_username = args[1]
@@ -17,6 +18,6 @@ proc.expect("Enter your username: ")
 proc.sendline(pypi_username)
 proc.expect("Enter your password: ")
 proc.sendline(pypi_password)
-proc = pexpect.spawn("cat /tmp/debug", encoding="utf-8") # debug
+time.sleep(0.1)
 proc.expect(pexpect.EOF)
 proc.close()

--- a/tools/script/deploy_to_pypi.py
+++ b/tools/script/deploy_to_pypi.py
@@ -10,7 +10,7 @@ pypi_username = args[1]
 pypi_password = args[2]
 is_test = args[3]
 pypi_repository = "testpypi" if is_test else "pypi"
-upload_command = "twine upload --repository " + pypi_repository + " dist/*"
+upload_command = "python3 -m twine upload --repository " + pypi_repository + " dist/*"
 proc = pexpect.spawn(upload_command, encoding="utf-8")
 proc.logfile = open("/tmp/debug", "w")  # debug
 proc.expect("Enter your username: ")

--- a/tools/script/deploy_to_pypi.py
+++ b/tools/script/deploy_to_pypi.py
@@ -17,5 +17,6 @@ proc.expect("Enter your username: ")
 proc.sendline(pypi_username)
 proc.expect("Enter your password: ")
 proc.sendline(pypi_password)
+proc = pexpect.spawn("cat /tmp/debug", encoding="utf-8") # debug
 proc.expect(pexpect.EOF)
 proc.close()


### PR DESCRIPTION
## Brief ##

pypi にデプロイする時のshellコマンドを修正し、githubactionsのパッケージの作成とpypiへのアップロードのプロセスを分離しました。
pypiへのアップロードがうまくいかなかった原因としては、シェルによるpypiへのアップロードのプロセスが完了する前にpythonのプロセスが終わっていたためです。sleepを足すことでうまくいくようになりました。
pypi, test.pypi共にgithubflowから更新しました。バージョンは一つupしています。
https://test.pypi.org/project/cliboa/#history
https://pypi.org/project/cliboa/#history

タグとリリースノート
https://github.com/BrainPad/cliboa/releases/tag/v2.0.1beta


## Points to Check ##
*  修正箇所
* pypiとtest.pypiのリリース履歴
* リリースノート

### Test ###
Confirming

（Write content to confirm / Reason why not necessary）

### Review Limit ###
* `Write review limit on pull request title.`
