### PR TITLE
[WIP] To continue processing even if some files failed

### DIFF
--- a/cliboa/scenario/transform/csv.py
+++ b/cliboa/scenario/transform/csv.py
@@ -18,7 +18,6 @@ import os
 import pandas
 from cliboa.adapter.sqlite import SqliteAdapter
 from cliboa.core.validator import EssentialParameters
-from cliboa.scenario.extras import ExceptionHandler
 from cliboa.scenario.transform.file import FileBaseTransform
 from cliboa.util.csv import Csv
 from cliboa.util.exception import (
@@ -411,7 +410,7 @@ class CsvConcat(FileBaseTransform):
         )
 
 
-class CsvConvert(FileBaseTransform, ExceptionHandler):
+class CsvConvert(FileBaseTransform):
     """
     Change csv format
     """
@@ -471,34 +470,30 @@ class CsvConvert(FileBaseTransform, ExceptionHandler):
         if self._after_enc is None:
             self._after_enc = self._before_enc
 
-        for fi, fo in super().io_files(files, ext=self._after_format):
-            try:
-                with open(fi, mode="rt", encoding=self._before_enc) as i:
-                    reader = csv.reader(
-                        i,
-                        delimiter=Csv.delimiter_convert(self._before_format),
-                        quoting=Csv.quote_convert(self._reader_quote)
-                    )
-                    with open(fo, mode="wt", newline="", encoding=self._after_enc) as o:
-                        writer = csv.writer(
-                            o,
-                            delimiter=Csv.delimiter_convert(self._after_format),
-                            quoting=Csv.quote_convert(self._quote),
-                            lineterminator=Csv.newline_convert(self._after_nl),
-                        )
+        super().io_files(files, ext=self._after_format)
 
-                        for i, line in enumerate(reader):
-                            if i == 0:
-                                if self._headers_existence is False:
-                                    continue
-                                writer.writerow(self._replace_headers(line))
-                            else:
-                                writer.writerow(line)
-            except Exception as e:
-                if self._force_continue is True:
-                    self.handle_error(e, fi)
-                else:
-                    raise e
+    def io_files_execute(self, fi, fo):
+        with open(fi, mode="rt", encoding=self._before_enc) as i:
+            reader = csv.reader(
+                i,
+                delimiter=Csv.delimiter_convert(self._before_format),
+                quoting=Csv.quote_convert(self._reader_quote)
+            )
+            with open(fo, mode="wt", newline="", encoding=self._after_enc) as o:
+                writer = csv.writer(
+                    o,
+                    delimiter=Csv.delimiter_convert(self._after_format),
+                    quoting=Csv.quote_convert(self._quote),
+                    lineterminator=Csv.newline_convert(self._after_nl),
+                )
+
+                for i, line in enumerate(reader):
+                    if i == 0:
+                        if self._headers_existence is False:
+                            continue
+                        writer.writerow(self._replace_headers(line))
+                    else:
+                        writer.writerow(line)
 
     def _replace_headers(self, old_headers):
         """


### PR DESCRIPTION
## Brief ##

To continue processing even if some files failed

## 内容 ##

スコープ

この修正は複数ファイルのinput/outputを行うクラスを対象とする
CsvConcatのようにinputは複数ファイルだが出力時は1ファイルになっているものや
FileDivideのようにinputは1ファイルだがoutputは複数ファイルになるものについては対象外とする

実装内容

実装前は子クラスでファイルの読み込みを行う際
execute関数内でsuper().io_files()での読み込みから読み込んだファイル全てに対する読み込み、加工、書き込みを行っており
親クラスではyield input_path, temp_file を返すのみであった
これを子クラスのexecute関数ではsuper().io_files()のみ実行し、残りの作業はio_files_execute関数内で行うこととする
親クラスのFileBaseTransformクラスではio_files_executeの実行時Exceptionが発生時設定yamlにforce_continue: trueが設定されていたらhandle_errorメソッドに記載された処理を実行することとする

対象クラス

FileBaseTransform

CsvColumnConcat
CsvColumnExtract
CsvColumnHash
CsvConvert (本p-rにて対応済)
CsvMergeExclusive
ColumnLengthAdjust
CsvToJsonl
DateFormatConvert
ExcelConvert
FileConvert

## Points to Check ##
* 1
* 2

### Test ###
Confirmed / Confirming / Not necessary

（Write content to confirm / Reason why not necessary）

### Review Limit ###
* `Write review limit on pull request title.`
