### PR TITLE
Only SftpDownload can execute the mkdir command

### DIFF
--- a/cliboa/scenario/extract/ftp.py
+++ b/cliboa/scenario/extract/ftp.py
@@ -11,6 +11,7 @@
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 #
+import os
 import re
 
 from cliboa.scenario.ftp import BaseFtp
@@ -43,6 +44,8 @@ class FtpDownload(FtpExtract):
             self.__class__.__name__, [self._host, self._user, self._src_dir, self._src_pattern],
         )
         valid()
+
+        os.makedirs(self._dest_dir, exist_ok=True)
 
         obj = FtpUtil().list_files(
             dir=self._src_dir,

--- a/cliboa/scenario/extract/sftp.py
+++ b/cliboa/scenario/extract/sftp.py
@@ -11,6 +11,7 @@
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 #
+import os
 import re
 
 from cliboa.scenario.sftp import BaseSftp
@@ -47,6 +48,8 @@ class SftpDownload(SftpExtract):
             self.__class__.__name__, [self._host, self._user, self._src_dir, self._src_pattern],
         )
         valid()
+
+        os.makedirs(self._dest_dir, exist_ok=True)
 
         obj = Sftp().list_files(
             dir=self._src_dir,

--- a/cliboa/scenario/ftp.py
+++ b/cliboa/scenario/ftp.py
@@ -11,8 +11,6 @@
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 #
-import os
-
 from cliboa.scenario.base import BaseStep
 from cliboa.adapter.ftp import FtpAdapter
 
@@ -39,7 +37,6 @@ class BaseFtp(BaseStep):
         self._src_pattern = src_pattern
 
     def dest_dir(self, dest_dir):
-        os.makedirs(dest_dir, exist_ok=True)
         self._dest_dir = dest_dir
 
     def host(self, host):

--- a/cliboa/scenario/sftp.py
+++ b/cliboa/scenario/sftp.py
@@ -11,7 +11,6 @@
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 #
-import os
 
 from cliboa.scenario.base import BaseStep
 from cliboa.adapter.sftp import SftpAdapter
@@ -41,7 +40,6 @@ class BaseSftp(BaseStep):
         self._src_pattern = src_pattern
 
     def dest_dir(self, dest_dir):
-        os.makedirs(dest_dir, exist_ok=True)
         self._dest_dir = dest_dir
 
     def host(self, host):

--- a/cliboa/scenario/transform/csv.py
+++ b/cliboa/scenario/transform/csv.py
@@ -54,6 +54,9 @@ class CsvColumnHash(FileBaseTransform):
         )
         valid()
 
+        if self._dest_dir:
+            os.makedirs(self._dest_dir, exist_ok=True)
+
         files = super().get_target_files(self._src_dir, self._src_pattern)
         self.check_file_existence(files)
 
@@ -86,6 +89,9 @@ class CsvColumnExtract(FileBaseTransform):
     def execute(self, *args):
         valid = EssentialParameters(self.__class__.__name__, [self._src_dir, self._src_pattern])
         valid()
+
+        if self._dest_dir:
+            os.makedirs(self._dest_dir, exist_ok=True)
 
         if not self._columns and not self._column_numbers:
             raise InvalidParameter("Specifying either 'column' or 'column_numbers' is essential.")
@@ -133,6 +139,9 @@ class CsvColumnConcat(FileBaseTransform):
             self.__class__.__name__, [self._src_dir, self._src_pattern, self._dest_column_name],
         )
         valid()
+
+        if self._dest_dir:
+            os.makedirs(self._dest_dir, exist_ok=True)
 
         if len(self._columns) < 2 or type(self._columns) is not list:
             raise InvalidParameter("'columns' must 2 or more lengths")
@@ -188,6 +197,9 @@ class CsvMergeExclusive(FileBaseTransform):
         )
         valid()
 
+        if self._dest_dir:
+            os.makedirs(self._dest_dir, exist_ok=True)
+
         files = super().get_target_files(self._src_dir, self._src_pattern)
         self.check_file_existence(files)
 
@@ -240,6 +252,9 @@ class ColumnLengthAdjust(FileBaseTransform):
         )
         valid()
 
+        if self._dest_dir:
+            os.makedirs(self._dest_dir, exist_ok=True)
+
         files = super().get_target_files(self._src_dir, self._src_pattern)
         self.check_file_existence(files)
         for fi, fo in super().io_writers(files, encoding=self._encoding):
@@ -285,6 +300,9 @@ class CsvMerge(FileBaseTransform):
             ],
         )
         valid()
+
+        if self._dest_dir:
+            os.makedirs(self._dest_dir, exist_ok=True)
 
         target1_files = File().get_target_files(self._src_dir, self._src1_pattern)
         target2_files = File().get_target_files(self._src_dir, self._src2_pattern)
@@ -341,6 +359,9 @@ class CsvColumnSelect(FileBaseTransform):
         )
         valid()
 
+        if self._dest_dir:
+            os.makedirs(self._dest_dir, exist_ok=True)
+
         files = File().get_target_files(self._src_dir, self._src_pattern)
         if len(files) == 0:
             raise FileNotFound("No files are found.")
@@ -377,6 +398,9 @@ class CsvConcat(FileBaseTransform):
             self.__class__.__name__, [self._src_dir, self._dest_dir, self._dest_name]
         )
         valid()
+
+        if self._dest_dir:
+            os.makedirs(self._dest_dir, exist_ok=True)
 
         if not self._src_pattern and not self._src_filenames:
             raise InvalidParameter(
@@ -463,6 +487,9 @@ class CsvConvert(FileBaseTransform, ExceptionHandler):
         )
         valid()
 
+        if self._dest_dir:
+            os.makedirs(self._dest_dir, exist_ok=True)
+
         files = super().get_target_files(self._src_dir, self._src_pattern)
         self.check_file_existence(files)
 
@@ -548,6 +575,9 @@ class CsvSort(FileBaseTransform):
         )
         valid()
 
+        if self._dest_dir:
+            os.makedirs(self._dest_dir, exist_ok=True)
+
         files = super().get_target_files(self._src_dir, self._src_pattern)
         self.check_file_existence(files)
 
@@ -588,6 +618,9 @@ class CsvToJsonl(FileBaseTransform):
         # essential parameters check
         valid = EssentialParameters(self.__class__.__name__, [self._src_dir, self._src_pattern])
         valid()
+
+        if self._dest_dir:
+            os.makedirs(self._dest_dir, exist_ok=True)
 
         files = super().get_target_files(self._src_dir, self._src_pattern)
         self.check_file_existence(files)

--- a/cliboa/scenario/transform/file.py
+++ b/cliboa/scenario/transform/file.py
@@ -66,7 +66,6 @@ class FileBaseTransform(BaseStep):
         self._src_pattern = src_pattern
 
     def dest_dir(self, dest_dir):
-        os.makedirs(dest_dir, exist_ok=True)
         self._dest_dir = dest_dir
 
     def dest_name(self, dest_name):


### PR DESCRIPTION
## Brief ##

In the current source code, if the path specified when executing SftpUpload does not exist, the mkdir command will be executed and an error will occur.
In the first place, creating a path at the upload destination when executing SftpUpload is not the intended behavior.
The mkdir command can be executed only when SftpDownload is executed when the specified path does not exist.

## Points to Check ##
* Is there any discomfort in the corresponding parts and contents?

### Test ###
Confirmed

All unit tests pass.
I confirmed that it behaved as expected in the [Development-Environment](https://github.com/BrainPad/cliboa/wiki/Development-Environment) . 

### Review Limit ###
* `I'd like to you to see it when you can see it.`
