### PR TITLE
Use psycopg2-binary instead of psycopg2

### DIFF
--- a/cliboa/template/Pipfile.above36
+++ b/cliboa/template/Pipfile.above36
@@ -38,7 +38,7 @@ azure-storage-blob = "==12.9.0"
 python-gnupg = "==0.4.8"
 openpyxl = "==3.0.9"
 pyminizip = "==0.2.5"
-psycopg2 = "==2.9.1"
+psycopg2-binary = "==2.9.1"
 
 [requires]
 python_version = "3.6"

--- a/cliboa/template/Pipfile.above37
+++ b/cliboa/template/Pipfile.above37
@@ -38,7 +38,7 @@ azure-storage-blob = "==12.9.0"
 python-gnupg = "==0.4.8"
 openpyxl = "==3.0.9"
 pyminizip = "==0.2.5"
-psycopg2 = "==2.9.1"
+psycopg2-binary = "==2.9.1"
 
 [requires]
 python_version = "3.7"

--- a/cliboa/template/Pipfile.above38
+++ b/cliboa/template/Pipfile.above38
@@ -38,7 +38,7 @@ azure-storage-blob = "==12.9.0"
 python-gnupg = "==0.4.8"
 openpyxl = "==3.0.9"
 pyminizip = "==0.2.5"
-psycopg2 = "==2.9.1"
+psycopg2-binary = "==2.9.1"
 
 [requires]
 python_version = "3.8"

--- a/cliboa/template/Pipfile.above39
+++ b/cliboa/template/Pipfile.above39
@@ -38,7 +38,7 @@ azure-storage-blob = "==12.9.0"
 python-gnupg = "==0.4.8"
 openpyxl = "==3.0.9"
 pyminizip = "==0.2.5"
-psycopg2 = "==2.9.1"
+psycopg2-binary = "==2.9.1"
 
 [requires]
 python_version = "3.9"

--- a/cliboa/template/requirements.above36.txt
+++ b/cliboa/template/requirements.above36.txt
@@ -49,6 +49,7 @@ pandas==0.25.3
 paramiko==2.8.1
 proto-plus==1.19.8; python_version >= '3.6'
 protobuf==3.19.1; python_version >= '3.6'
+psycopg2-binary==2.9.1
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pycparser==2.21

--- a/cliboa/template/requirements.above37.txt
+++ b/cliboa/template/requirements.above37.txt
@@ -52,6 +52,7 @@ pandas==1.3.4
 paramiko==2.8.1
 proto-plus==1.19.8; python_version >= '3.6'
 protobuf==3.19.1; python_version >= '3.6'
+psycopg2-binary==2.9.1
 pyarrow==6.0.1
 pyasn1-modules==0.2.8
 pyasn1==0.4.8

--- a/cliboa/template/requirements.above38.txt
+++ b/cliboa/template/requirements.above38.txt
@@ -52,6 +52,7 @@ pandas==1.3.4
 paramiko==2.8.1
 proto-plus==1.19.8; python_version >= '3.6'
 protobuf==3.19.1; python_version >= '3.6'
+psycopg2-binary==2.9.1
 pyarrow==6.0.1
 pyasn1-modules==0.2.8
 pyasn1==0.4.8

--- a/cliboa/template/requirements.above39.txt
+++ b/cliboa/template/requirements.above39.txt
@@ -52,6 +52,7 @@ pandas==1.3.4
 paramiko==2.8.1
 proto-plus==1.19.8; python_version >= '3.6'
 protobuf==3.19.1; python_version >= '3.6'
+psycopg2-binary==2.9.1
 pyarrow==6.0.1
 pyasn1-modules==0.2.8
 pyasn1==0.4.8


### PR DESCRIPTION
## Brief ##

Attempting to install psycopg2 in an environment without PostgreSQL fails with the following error.

  
```
  pg_config is required to build psycopg2 from source.  Please add the directory
  containing pg_config to the $PATH or specify the full executable path with the
  option:
  
      python setup.py build_ext --pg-config /path/to/pg_config build ...
  
  or with the pg_config option in 'setup.cfg'.
  
  If you prefer to avoid building psycopg2 from source, please install the PyPI
  'psycopg2-binary' package instead.
  
  For further information please check the 'doc/src/install.rst' file (also at
  <https://www.psycopg.org/docs/install.html>).
```
Install psycopg2-binary instead of psycopg2.

## Points to Check ##
* Is there any discomfort in the corresponding parts and contents?

### Test ###
Confirmed 

All unit tests pass.
I confirmed that it behaved as expected in the Development-Environment .

### Review Limit ###
* `As soon as possible.`
