### PR TITLE
On branch 322 Update of debian Dockerfile for development

### DIFF
--- a/cliboa/template/Pipfile.above36
+++ b/cliboa/template/Pipfile.above36
@@ -38,7 +38,7 @@ azure-storage-blob = "==12.9.0"
 python-gnupg = "==0.4.8"
 openpyxl = "==3.0.9"
 pyminizip = "==0.2.5"
-psycopg2-binary = "==2.9.1"
+psycopg2 = "==2.9.1"
 
 [requires]
 python_version = "3.6"

--- a/cliboa/template/Pipfile.above37
+++ b/cliboa/template/Pipfile.above37
@@ -38,7 +38,7 @@ azure-storage-blob = "==12.9.0"
 python-gnupg = "==0.4.8"
 openpyxl = "==3.0.9"
 pyminizip = "==0.2.5"
-psycopg2-binary = "==2.9.1"
+psycopg2 = "==2.9.1"
 
 [requires]
 python_version = "3.7"

--- a/cliboa/template/Pipfile.above38
+++ b/cliboa/template/Pipfile.above38
@@ -38,7 +38,7 @@ azure-storage-blob = "==12.9.0"
 python-gnupg = "==0.4.8"
 openpyxl = "==3.0.9"
 pyminizip = "==0.2.5"
-psycopg2-binary = "==2.9.1"
+psycopg2 = "==2.9.1"
 
 [requires]
 python_version = "3.8"

--- a/cliboa/template/Pipfile.above39
+++ b/cliboa/template/Pipfile.above39
@@ -38,7 +38,7 @@ azure-storage-blob = "==12.9.0"
 python-gnupg = "==0.4.8"
 openpyxl = "==3.0.9"
 pyminizip = "==0.2.5"
-psycopg2-binary = "==2.9.1"
+psycopg2 = "==2.9.1"
 
 [requires]
 python_version = "3.9"

--- a/cliboa/template/requirements.above36.txt
+++ b/cliboa/template/requirements.above36.txt
@@ -49,7 +49,7 @@ pandas==0.25.3
 paramiko==2.8.1
 proto-plus==1.19.8; python_version >= '3.6'
 protobuf==3.19.1; python_version >= '3.6'
-psycopg2-binary==2.9.1
+psycopg2==2.9.1
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pycparser==2.21

--- a/cliboa/template/requirements.above37.txt
+++ b/cliboa/template/requirements.above37.txt
@@ -52,7 +52,7 @@ pandas==1.3.4
 paramiko==2.8.1
 proto-plus==1.19.8; python_version >= '3.6'
 protobuf==3.19.1; python_version >= '3.6'
-psycopg2-binary==2.9.1
+psycopg2==2.9.1
 pyarrow==6.0.1
 pyasn1-modules==0.2.8
 pyasn1==0.4.8

--- a/cliboa/template/requirements.above38.txt
+++ b/cliboa/template/requirements.above38.txt
@@ -52,7 +52,7 @@ pandas==1.3.4
 paramiko==2.8.1
 proto-plus==1.19.8; python_version >= '3.6'
 protobuf==3.19.1; python_version >= '3.6'
-psycopg2-binary==2.9.1
+psycopg2==2.9.1
 pyarrow==6.0.1
 pyasn1-modules==0.2.8
 pyasn1==0.4.8

--- a/cliboa/template/requirements.above39.txt
+++ b/cliboa/template/requirements.above39.txt
@@ -52,7 +52,7 @@ pandas==1.3.4
 paramiko==2.8.1
 proto-plus==1.19.8; python_version >= '3.6'
 protobuf==3.19.1; python_version >= '3.6'
-psycopg2-binary==2.9.1
+psycopg2==2.9.1
 pyarrow==6.0.1
 pyasn1-modules==0.2.8
 pyasn1==0.4.8

--- a/tools/docker/debian/Dockerfile
+++ b/tools/docker/debian/Dockerfile
@@ -17,13 +17,13 @@ RUN apt update -y && \
                    tk-dev \
                    pinentry-curses \
                    python \
-                   python-pip \
                    python3 \
                    python3-pip \
                    vim \
                    virtualenv \
                    wget \
-                   zlib1g-dev
+                   zlib1g-dev \
+                   libpq-dev
 
 # Download multiple python versions which cliboa supports
 RUN cd /usr/local/ && \


### PR DESCRIPTION
## Brief ##
開発環境用DockerのDockerfileを更新しました。また、次の公式ドキュメントに記載の通りpsycopg2-binaryは本番用途に向かないようですので修正しました。
https://pypi.org/project/psycopg2/

issues
https://github.com/BrainPad/cliboa/issues/322

## Points to Check ##
修正後のDockerfileでテストが処理されること。

補足
cliboaのpostgre機能を利用する場合、postgresql本体の関連ライブラリがインストールされる想定ですので、開発用dockerには必要最小限のライブラリのみ追加しました。

### Test ###
実行済み

### Review Limit ###
お手隙の時に
