### PR TITLE
Remove Python 3.5 description from pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,18 +64,16 @@ setup(
     package_data={
         "cliboa.conf": ["logging.conf", "cliboa.ini"],
         "cliboa.template": [
-            "Pipfile.above35",
             "Pipfile.above36",
             "Pipfile.above37",
             "Pipfile.above38",
             "Pipfile.above39",
-            "requirements.above35.txt",
             "requirements.above36.txt",
             "requirements.above37.txt",
             "requirements.above38.txt",
             "requirements.above39.txt",
         ],
     },
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     entry_points={"console_scripts": ["cliboadmin = cliboa.cli.cliboadmin:main"]},
 )


### PR DESCRIPTION
## Brief ##

Remove Python 3.5 description from pypi

## Points to Check ##
* Is there any discomfort in the corresponding parts and contents?

### Test ###

Not necessary

This change does not affect the actual processing.

### Review Limit ###
* `I would like it at the timing of your chance.`
