### PR TITLE
Add CsvcolumnDelete

### DIFF
--- a/cliboa/scenario/__init__.py
+++ b/cliboa/scenario/__init__.py
@@ -38,6 +38,7 @@ from .sqlite import SqliteQueryExecute
 from .transform.csv import (
     ColumnLengthAdjust,
     CsvColumnConcat,
+    CsvColumnDelete,
     CsvColumnExtract,
     CsvColumnHash,
     CsvConcat,

--- a/cliboa/scenario/transform/csv.py
+++ b/cliboa/scenario/transform/csv.py
@@ -85,16 +85,12 @@ class CsvColumnExtract(FileBaseTransform):
         super().__init__()
         self._columns = None
         self._column_numbers = None
-        self._do_delete = False
 
     def columns(self, columns):
         self._columns = columns
 
     def column_numbers(self, column_numbers):
         self._column_numbers = column_numbers
-
-    def do_delete(self, do_delete):
-        self._do_delete = do_delete
 
     def execute(self, *args):
         valid = EssentialParameters(self.__class__.__name__, [self._src_dir, self._src_pattern])
@@ -114,31 +110,61 @@ class CsvColumnExtract(FileBaseTransform):
         super().io_files(files, func=self.convert)
 
     def convert(self, fi, fo):
-        if self._do_delete:
-            df = pandas.read_csv(
-                fi,
-                dtype=str,
-                encoding=self._encoding,
-            )
-            if self._columns:
-                df = df.drop(self._columns, axis=1)
-            elif self._column_numbers:
-                df = df.drop(df.columns[list(map(int, self._column_numbers.split(",")))], axis=1)
-            df.to_csv(
-                fo,
-                encoding=self._encoding,
-                index=False,
-            )
-        else:
-            if self._columns:
-                Csv.extract_columns_with_names(fi, fo, self._columns)
-            elif self._column_numbers:
-                if isinstance(self._column_numbers, int) is True:
-                    remain_column_numbers = [self._column_numbers]
-                else:
-                    column_numbers = self._column_numbers.split(",")
-                    remain_column_numbers = [int(n) for n in column_numbers]
-                Csv.extract_columns_with_numbers(fi, fo, remain_column_numbers)
+        if self._columns:
+            Csv.extract_columns_with_names(fi, fo, self._columns)
+        elif self._column_numbers:
+            if isinstance(self._column_numbers, int) is True:
+                remain_column_numbers = [self._column_numbers]
+            else:
+                column_numbers = self._column_numbers.split(",")
+                remain_column_numbers = [int(n) for n in column_numbers]
+            Csv.extract_columns_with_numbers(fi, fo, remain_column_numbers)
+
+
+class CsvColumnDelete(FileBaseTransform):
+    """
+    Delete specific columns from csv file.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._regex_pattern = None
+
+    def regex_pattern(self, regex_pattern):
+        self._regex_pattern = regex_pattern
+
+    def execute(self, *args):
+        valid = EssentialParameters(self.__class__.__name__, [self._src_dir, self._src_pattern])
+        valid()
+
+        if not self._regex_pattern:
+            raise InvalidParameter("'regex_pattern' is essential.")
+
+        files = super().get_target_files(self._src_dir, self._src_pattern)
+        self.check_file_existence(files)
+
+        super().io_files(files, func=self.convert)
+
+    def convert(self, fi, fo):
+        df = pandas.read_csv(
+            fi,
+            dtype=str,
+            encoding=self._encoding,
+        )
+        pattern = re.compile(self._regex_pattern)
+        for column in df.columns.values:
+            if pattern.fullmatch(column):
+                df = df.drop(column, axis=1)
+
+        # output an empty file when all columns are deleted
+        if df.empty:
+            df = df.dropna(how="all")
+
+        df.to_csv(
+            fo,
+            encoding=self._encoding,
+            index=False,
+        )
 
 
 class CsvValueExtract(FileBaseTransform):

--- a/docs/modules/csv_column_delete.md
+++ b/docs/modules/csv_column_delete.md
@@ -1,0 +1,32 @@
+# CsvColumnDelete
+Delete specific columns from csv files.
+
+# Parameters
+|Parameters|Explanation|Required|Default|Remarks|
+|----------|-----------|--------|-------|-------|
+|src_dir|Path of the directory which target files are placed.|Yes|None||
+|src_pattern|Regex which is to find target files.|Yes|None||
+|dest_dir|Path of the directory which is for output files.|No|None||
+|regex_pattern|Column and regular expression pair.|Yes|None||
+
+# Example
+```
+scenario:
+- step:
+  class: CsvColumnDelete
+  arguments:
+    src_dir: /in
+    src_pattern: test\.csv
+    dest_dir: /out
+    regex_pattern: '^.*_1$'
+
+Input: /in/test.csv
+col_1, col_2
+1, one
+2, two
+
+Output: /out/test.csv
+col_2
+one
+two
+```

--- a/docs/modules/csv_column_extract.md
+++ b/docs/modules/csv_column_extract.md
@@ -8,10 +8,9 @@ Extract specific columns from csv files.
 |src_pattern|Regex which is to find target files.|Yes|None||
 |dest_dir|Path of the directory which is for output files.|No|None||
 |encoding|Character encoding when read and write|No|utf-8||
-|columns|Columns to keep if extracting columns. If you want to delete columns specify the columns to delete|No|None|Specify either columns or column_num is essential.|
-|column_numbers|Column numbers to keep if extracting columns. If you want to delete columns specify the column numbers to delete|No|None|Can specify several column number by comma. Specify 1 as the first column number.|
+|columns|Columns that remains for new csv file|No|None|Specify either columns or column_num is essential.|
+|column_numbers|Column numbers that remains for new csv file|No|None|Can specify several column number by comma. Specify 1 as the first column number.|
 |nonfile_error|Whether an error is thrown when files are not found in src_dir.|No|False||
-|do_delete|When True is specified, delete the columns specified in columns or column_numbers. When False is specified, leave the columns specified in columns or column_numbers|No|False||
 
 
 # Example 1


### PR DESCRIPTION
## Brief ##

Add CsvcolumnDelete
Restore the deletion mode of CsvColumnExtract performed by [This pull request](https://github.com/BrainPad/cliboa/pull/360) at the time of this correspondence to the state before implementation

## Points to Check ##
* Is the deletion mode of CsvColumnExtract in the state before implementation?
* Validity of implementation contents of CsvcolumnDelete

### Test ###
Confirmed

All unit tests pass.
I confirmed that it behaved as expected in the [Development-Environment.](https://github.com/BrainPad/cliboa/wiki/Development-Environment)

### Review Limit ###
* `As soon as possible.`
