### PR TITLE
[modify] say command

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -9,6 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: install git-secrets
         run: |
+          sudo ln -s "$(which echo)" /usr/local/bin/say
           git clone https://github.com/awslabs/git-secrets.git git-secrets
           cd git-secrets
           sudo make install


### PR DESCRIPTION
## Brief ##

git-secretsの修正

- gitのバージョンアップによりsayコマンドがなくなった（らしい）ので、sayコマンドのpathが通る様にした
- https://github.com/awslabs/git-secrets/issues/220

## Points to Check ##
* CIが落ちていないか？
* この対応で問題ないか？

### Test ###
Confirmed

- CIが通った
    - https://github.com/Tsuyoposon/cliboa/commit/22f7798fd4b5775ac7849ef5fa1b5cbdbae9a0db

### Review Limit ###
* いつでも
