### PR TITLE
Set default value to chunk_size in FileCompress class

### DIFF
--- a/cliboa/scenario/transform/file.py
+++ b/cliboa/scenario/transform/file.py
@@ -266,7 +266,7 @@ class FileCompress(FileBaseTransform):
     def __init__(self):
         super().__init__()
         self._format = None
-        self._chunk_size = None
+        self._chunk_size = 1048576
 
     def format(self, format):
         self._format = format.lower()
@@ -277,7 +277,8 @@ class FileCompress(FileBaseTransform):
     def execute(self, *args):
         # essential parameters check
         valid = EssentialParameters(
-            self.__class__.__name__, [self._src_dir, self._src_pattern, self._format]
+            self.__class__.__name__,
+            [self._src_dir, self._src_pattern, self._format],
         )
         valid()
 

--- a/cliboa/test/scenario/transform/test_file.py
+++ b/cliboa/test/scenario/transform/test_file.py
@@ -371,6 +371,7 @@ class TestFileCompress(TestFileTransform):
         Helper.set_property(instance, "src_pattern", r"test.*\.txt")
         Helper.set_property(instance, "dest_dir", self._out_dir)
         Helper.set_property(instance, "format", "gz")
+        Helper.set_property(instance, "chunk_size", 1024)
         instance.execute()
 
         compressed_file_1 = os.path.join(self._out_dir, "test1.txt.gz")
@@ -407,6 +408,7 @@ class TestFileCompress(TestFileTransform):
         Helper.set_property(instance, "src_pattern", r"test.*\.txt")
         Helper.set_property(instance, "dest_dir", self._out_dir)
         Helper.set_property(instance, "format", "bz2")
+        Helper.set_property(instance, "chunk_size", 1024)
         instance.execute()
 
         compressed_file_1 = os.path.join(self._out_dir, "test1.txt.bz2")

--- a/docs/modules/file_compress.md
+++ b/docs/modules/file_compress.md
@@ -9,7 +9,7 @@ Compress files by any of the following compression type
 |src_pattern|Regex to search files.|Yes|None||
 |dest_dir|Directory to output compressed files|No|None|Compressed files are created in the same directory of the un-compressed files, if this parameter is not set.If a non-existent directory path is specified, the directory is automatically created.|
 |format|Any of the following. [gz(gzip), bz2(bzip2), zip]|Yes|None||
-|chunk_size|The chunk size bytes, to be used for decompressing data streams that won’t fit into memory at once.|No|None||
+|chunk_size|The chunk size bytes, to be used for decompressing data streams that won’t fit into memory at once.|No|1048576||
 |nonfile_error|Whether an error is thrown when files are not found in src_dir.|No|False||
 
 # Examples


### PR DESCRIPTION
## Brief ##

FileCompress class must specify chunk_size as mandatory

## Points to Check ##
* Is there any discomfort in the corresponding parts and contents?

### Test ###
Confirmed

All unit tests pass.
I confirmed that it behaved as expected in the [Development-Environment.](https://github.com/BrainPad/cliboa/wiki/Development-Environment)

### Review Limit ###
* `When you're ready.`
