### PR TITLE
Add a mode to judge FileRename Class without distinguishing file extensions

### DIFF
--- a/cliboa/test/scenario/transform/test_file.py
+++ b/cliboa/test/scenario/transform/test_file.py
@@ -811,6 +811,40 @@ class TestFileRename(TestFileTransform):
         assert os.path.exists(os.path.join(self._data_dir, "ataeasata1a.txt"))
         assert os.path.exists(os.path.join(self._data_dir, "ataeasata2a.txt"))
 
+    def test_execute_ok_11(self):
+        self._create_files()
+
+        instance = FileRename()
+        Helper.set_property(instance, "logger", LisboaLog.get_logger(__name__))
+        Helper.set_property(instance, "src_dir", self._data_dir)
+        Helper.set_property(instance, "src_pattern", r"test.*\.txt")
+        Helper.set_property(instance, "regex_pattern", "test")
+        Helper.set_property(instance, "rep_str", "test_")
+        Helper.set_property(instance, "without_ext", False)
+        instance.execute()
+
+        assert os.path.exists(os.path.join(self._data_dir, "test_1.txt"))
+        assert os.path.exists(os.path.join(self._data_dir, "test_2.txt"))
+
+    def test_execute_ok_12(self):
+        self._create_files()
+        files = self._create_files()
+        for file in files:
+            root, name = os.path.split(file)
+            os.rename(file, os.path.join(root, name + ".12345"))
+
+        instance = FileRename()
+        Helper.set_property(instance, "logger", LisboaLog.get_logger(__name__))
+        Helper.set_property(instance, "src_dir", self._data_dir)
+        Helper.set_property(instance, "src_pattern", r"test.*\.txt\.12345")
+        Helper.set_property(instance, "regex_pattern", ".txt")
+        Helper.set_property(instance, "rep_str", "_txt")
+        Helper.set_property(instance, "without_ext", False)
+        instance.execute()
+
+        assert os.path.exists(os.path.join(self._data_dir, "test1_txt.12345"))
+        assert os.path.exists(os.path.join(self._data_dir, "test2_txt.12345"))
+
     def test_execute_ng_1(self):
         self._create_files()
 
@@ -823,7 +857,7 @@ class TestFileRename(TestFileTransform):
         Helper.set_property(instance, "regex_pattern", "test1")
         with pytest.raises(InvalidParameter) as execinfo:
             instance.execute()
-        assert "The converted string is not defined in yaml file: dest_str" == str(execinfo.value)
+        assert "Replace string is not defined in yaml file: rep_str" == str(execinfo.value)
 
     def test_execute_ng_2(self):
         self._create_files()
@@ -853,7 +887,7 @@ class TestFileRename(TestFileTransform):
         Helper.set_property(instance, "regex_pattern", "")
         with pytest.raises(InvalidParameter) as execinfo:
             instance.execute()
-        assert "The converted string is not defined in yaml file: dest_str" == str(execinfo.value)
+        assert "Replace string is not defined in yaml file: rep_str" == str(execinfo.value)
 
     def test_execute_ng_4(self):
         self._create_files()
@@ -870,6 +904,45 @@ class TestFileRename(TestFileTransform):
         assert "The conversion pattern is not defined in yaml file: regex_pattern" == str(
             execinfo.value
         )
+
+    def test_execute_ng_5(self):
+        self._create_files()
+
+        instance = FileRename()
+        Helper.set_property(instance, "logger", LisboaLog.get_logger(__name__))
+        Helper.set_property(instance, "src_dir", self._data_dir)
+        Helper.set_property(instance, "src_pattern", r"test.*\.txt")
+        Helper.set_property(instance, "prefix", "PRE-")
+        Helper.set_property(instance, "without_ext", False)
+        with pytest.raises(InvalidParameter) as execinfo:
+            instance.execute()
+        assert "Cannot be specified in without_ext mode" == str(execinfo.value)
+
+    def test_execute_ng_6(self):
+        self._create_files()
+
+        instance = FileRename()
+        Helper.set_property(instance, "logger", LisboaLog.get_logger(__name__))
+        Helper.set_property(instance, "src_dir", self._data_dir)
+        Helper.set_property(instance, "src_pattern", r"test.*\.txt")
+        Helper.set_property(instance, "suffix", "-SUF")
+        Helper.set_property(instance, "without_ext", False)
+        with pytest.raises(InvalidParameter) as execinfo:
+            instance.execute()
+        assert "Cannot be specified in without_ext mode" == str(execinfo.value)
+
+    def test_execute_ng_7(self):
+        self._create_files()
+
+        instance = FileRename()
+        Helper.set_property(instance, "logger", LisboaLog.get_logger(__name__))
+        Helper.set_property(instance, "src_dir", self._data_dir)
+        Helper.set_property(instance, "src_pattern", r"test.*\.txt")
+        Helper.set_property(instance, "ext", "csv")
+        Helper.set_property(instance, "without_ext", False)
+        with pytest.raises(InvalidParameter) as execinfo:
+            instance.execute()
+        assert "Cannot be specified in without_ext mode" == str(execinfo.value)
 
 
 class TestFileConvert(TestFileTransform):

--- a/docs/modules/file_rename.md
+++ b/docs/modules/file_rename.md
@@ -2,18 +2,19 @@
 Renaming files with adding either prefix or suffix.
 
 # Parameters
-|Parameters|Explanation|Required|Default|Remarks|
-|----------|-----------|--------|-------|-------|
-|src_dir|Path of the directory which target files are placed.|Yes|None||
-|src_pattern|Regex which is to find target files.|Yes|None||
-|prefix|Prefix for new file name|No|`""`||
-|suffix|Suffix for new file name|No|`""`||
-|regex_pattern|Pattern when conversion.|No|None|Fails if both regex_pattern and dest_str are not defined.|
-|rep_str|Converted string in the file name.|No|None|Fails if both regex_pattern and dest_str are not defined.|
-|ext|Converted file extension.|No|`""`|Only change the extension, not the file format.|
-|nonfile_error|Whether an error is thrown when files are not found in src_dir.|No|False||
+| Parameters    | Explanation                                                                   | Required | Default | Remarks                                                                                                                                                                                                  |
+|---------------|-------------------------------------------------------------------------------|----------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| src_dir       | Path of the directory which target files are placed.                          | Yes      | None    |                                                                                                                                                                                                          |
+| src_pattern   | Regex which is to find target files.                                          | Yes      | None    |                                                                                                                                                                                                          |
+| prefix        | Prefix for new file name                                                      | No       | `""`    |                                                                                                                                                                                                          |
+| suffix        | Suffix for new file name                                                      | No       | `""`    |                                                                                                                                                                                                          |
+| regex_pattern | Pattern when conversion.                                                      | No       | None    | Fails if both regex_pattern and rep_str are not defined.                                                                                                                                                 |
+| rep_str       | Converted string in the file name.                                            | No       | None    | Fails if both regex_pattern and rep_str are not defined.                                                                                                                                                 |
+| ext           | Converted file extension.                                                     | No       | `""`    | Only change the extension, not the file format.                                                                                                                                                          |
+| nonfile_error | Whether an error is thrown when files are not found in src_dir.               | No       | False   |                                                                                                                                                                                                          |
+| without_ext   | Include the extension in the range when converting using regular expressions. | No       | False   | Fails if without_ext is True, only one of the regex_pattern or rep_str are specified. Fails if without_ext is False, both regex_pattern and rep_str are not defined, and specify prefix and suffix, ext. |
 
-# Examples
+# Example1
 ```
 scenario:
 - step: Rename file
@@ -29,7 +30,10 @@ scenario:
 
 Input: /root/foo.txt
 Output: /root/PRE_hoo_SUF.csv
+```
 
+# Example2
+```
 scenario:
 - step: Rename file (deletion of character)
   class: FileRename
@@ -41,4 +45,20 @@ scenario:
 
 Input: /root/foo_delete.txt
 Output: /root/foo.csv
+```
+
+# Example3
+```
+scenario:
+- step: Rename file（without distinguishing extension）
+  class: FileRename
+  arguments:
+    src_dir: /root
+    src_pattern: foo\.1\.txt
+    regex_pattern: \.1\.txt
+    rep_str: _1.txt
+    without_ext: False
+
+Input: /root/foo.1.txt
+Output: /root/foo_1.txt
 ```


### PR DESCRIPTION
## Brief ##

Add a mode to judge FileRename Class without distinguishing file extensions

## Points to Check ##
* Is there any discomfort in the corresponding parts and contents?

### Test ###
Confirmed

### Review Limit ###
* `When you're ready.`
