### PR TITLE
Create a mode that does not generate intermediate files in SftpUpload.

### DIFF
--- a/cliboa/scenario/load/sftp.py
+++ b/cliboa/scenario/load/sftp.py
@@ -33,12 +33,16 @@ class SftpUpload(SftpBaseLoad):
         super().__init__()
         self._quit = False
         self._ignore_empty_file = False
+        self._put_intermediation = "."
 
     def quit(self, quit):
         self._quit = quit
 
     def ignore_empty_file(self, ignore_empty_file):
         self._ignore_empty_file = ignore_empty_file
+
+    def put_intermediation(self, put_intermediation):
+        self._put_intermediation = put_intermediation
 
     def execute(self, *args):
         # essential parameters check
@@ -61,6 +65,7 @@ class SftpUpload(SftpBaseLoad):
                 ).put_file(
                     src=file,
                     dest=os.path.join(self._dest_dir, os.path.basename(file)),
+                    put_intermediation=self._put_intermediation,
                     endfile_suffix=self._endfile_suffix,
                 )
                 adaptor.execute(obj)

--- a/docs/modules/sftp_upload.md
+++ b/docs/modules/sftp_upload.md
@@ -2,22 +2,23 @@
 Upload a file via SFTP.
 
 # Parameters
-|Parameters|Explanation|Required|Default|Remarks|
-|----------|-----------|--------|-------|-------|
-|host|Host name or IP address of a sftp server.|Yes|None||
-|user|User name for authentication|Yes|None||
-|password|Password for authentication|No|None|Either password or key is required|
-|key|Path to key for authentication|No|None||
-|passphrase|Used for decrypting key|No|None||
-|port|Port number of a sftp server|No|22||
-|src_dir|Directory of source to upload|Yes|None||
-|src_pattern|File pattern of source to upload. Regexp is available.|Yes|None||
-|dest_dir|Destination directory to upload.|No|None|
-|endfile_suffix|Places file with original file name + ".endfile_suffix" when upload completed.|No|None||
-|timeout|Timeout period of sftp connection. Unit is second.|No|30||
-|retry_count|retry count of sftp connection.|No|3||
-|quit|True or False flag for quitting cliboa process when source files do not exist.|No|False||
-|ignore_empty_file|If True, size zero files are not be uploaded|No|False||
+| Parameters         | Explanation                                                                    | Required | Default | Remarks                                                                 |
+|--------------------|--------------------------------------------------------------------------------|----------|---------|-------------------------------------------------------------------------|
+| host               | Host name or IP address of a sftp server.                                      | Yes      | None    |                                                                         |
+| user               | User name for authentication                                                   | Yes      | None    |                                                                         |
+| password           | Password for authentication                                                    | No       | None    | Either password or key is required                                      |
+| key                | Path to key for authentication                                                 | No       | None    |                                                                         |
+| passphrase         | Used for decrypting key                                                        | No       | None    |                                                                         |
+| port               | Port number of a sftp server                                                   | No       | 22      |                                                                         |
+| src_dir            | Directory of source to upload                                                  | Yes      | None    |                                                                         |
+| src_pattern        | File pattern of source to upload. Regexp is available.                         | Yes      | None    |                                                                         |
+| dest_dir           | Destination directory to upload.                                               | No       | None    |                                                                         |
+| endfile_suffix     | Places file with original file name + ".endfile_suffix" when upload completed. | No       | None    |                                                                         |
+| timeout            | Timeout period of sftp connection. Unit is second.                             | No       | 30      |                                                                         |
+| retry_count        | retry count of sftp connection.                                                | No       | 3       |                                                                         |
+| quit               | True or False flag for quitting cliboa process when source files do not exist. | No       | False   |                                                                         |
+| ignore_empty_file  | If True, size zero files are not be uploaded                                   | No       | False   |                                                                         |
+| put_intermediation | Specify prefix to be added to the intermediate file created when PUT file.     | No       | .       | If you do not want to create an intermediate file, define it as "None". |
 
 # Examples
 ```


### PR DESCRIPTION
## Brief ##

Create a mode that does not generate intermediate files in SftpUpload.

## Points to Check ##
* Is there any discomfort in the corresponding parts and contents?

### Test ###
Confirmed

I was able to transfer files using the modified SftpUpload class.  
I was able to transfer files by adding the put_intermediation option.  
I was able to transfer files by specifying None for the put_intermediation option.  
The contents of the file did not change before and after the transfer.  
I confirmed the above.  

### Review Limit ###
* `As soon as possible.`
