### PR TITLE
Implement DynamoDBWrite class.

### DIFF
--- a/cliboa/scenario/__init__.py
+++ b/cliboa/scenario/__init__.py
@@ -27,7 +27,7 @@ from .extract.mysql import MysqlRead
 from .extract.postgres import PostgresqlRead
 from .extract.sftp import SftpDelete, SftpDownload, SftpDownloadFileDelete, SftpFileExistsCheck
 from .extract.sqlite import SqliteExport
-from .load.aws import S3Upload, DynamoDBWrite
+from .load.aws import DynamoDBWrite, S3Upload
 from .load.azure import AzureBlobUpload
 from .load.gcp import BigQueryCopy, BigQueryWrite, FirestoreDocumentCreate, GcsUpload
 from .load.http import HttpDelete, HttpPost

--- a/cliboa/scenario/__init__.py
+++ b/cliboa/scenario/__init__.py
@@ -27,7 +27,7 @@ from .extract.mysql import MysqlRead
 from .extract.postgres import PostgresqlRead
 from .extract.sftp import SftpDelete, SftpDownload, SftpDownloadFileDelete, SftpFileExistsCheck
 from .extract.sqlite import SqliteExport
-from .load.aws import S3Upload
+from .load.aws import S3Upload, DynamoDBWrite
 from .load.azure import AzureBlobUpload
 from .load.gcp import BigQueryCopy, BigQueryWrite, FirestoreDocumentCreate, GcsUpload
 from .load.http import HttpDelete, HttpPost

--- a/cliboa/scenario/load/aws.py
+++ b/cliboa/scenario/load/aws.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 BrainPad Inc. All Rights Reserved.
+# Copyright BrainPad Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -11,12 +11,17 @@
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 #
+import csv
+import json
 import os
 
+import boto3
+
 from cliboa.adapter.aws import S3Adapter
-from cliboa.scenario.aws import BaseS3
+from cliboa.scenario.aws import BaseAws, BaseS3
 from cliboa.scenario.validator import EssentialParameters
 from cliboa.util.constant import StepStatus
+from cliboa.util.exception import FileNotFound, InvalidFormat, InvalidParameter
 
 
 class S3Upload(BaseS3):
@@ -71,3 +76,120 @@ class S3Upload(BaseS3):
             )
             if self._quit is True:
                 return StepStatus.SUCCESSFUL_TERMINATION
+
+
+class DynamoDBWrite(BaseAws):
+    """
+    Class to write data from CSV or JSONL files to DynamoDB
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._table_name = None
+        self._src_dir = None
+        self._src_pattern = None
+        self._file_format = "csv"
+
+    def table_name(self, table_name):
+        self._table_name = table_name
+
+    def src_dir(self, src_dir):
+        self._src_dir = src_dir
+
+    def src_pattern(self, src_pattern):
+        self._src_pattern = src_pattern
+
+    def file_format(self, file_format):
+        if file_format not in ["csv", "jsonl"]:
+            raise InvalidParameter("file_format must be either 'csv' or 'jsonl'")
+        self._file_format = file_format
+
+    def execute(self, *args):
+        valid = EssentialParameters(
+            self.__class__.__name__,
+            [self._table_name, self._src_dir, self._src_pattern, self._file_format],
+        )
+        valid()
+
+        files = super().get_target_files(self._src_dir, self._src_pattern)
+        if len(files) == 0:
+            raise FileNotFound("Target file was not found.")
+
+        dynamodb = boto3.resource("dynamodb", region_name=self._region)
+
+        try:
+            table = dynamodb.Table(self._table_name)
+            table.load()
+
+            table_info = table.key_schema
+            partition_key = next(key for key in table_info if key["KeyType"] == "HASH")[
+                "AttributeName"
+            ]
+            sort_key = next(
+                (key["AttributeName"] for key in table_info if key["KeyType"] == "RANGE"), None
+            )
+        except dynamodb.meta.client.exceptions.ResourceNotFoundException:
+            self._logger.error(f"Table '{self._table_name}' does not exist.")
+            raise
+
+        for file in files:
+            if self._file_format.lower() == "csv":
+                self._write_csv_to_dynamodb(file, table, partition_key, sort_key)
+            elif self._file_format.lower() == "jsonl":
+                self._write_jsonl_to_dynamodb(file, table, partition_key, sort_key)
+            else:
+                raise InvalidParameter(f"Unsupported file type: {self._file_format}")
+
+        self._logger.info("Data has been written to DynamoDB.")
+
+    def _write_csv_to_dynamodb(self, file, table, partition_key, sort_key):
+        """Write CSV file to DynamoDB
+        Args:
+            file (str): File path
+            table (boto3.resources.factory.dynamodb.Table): DynamoDB table
+            partition_key (str): Partition key
+            sort_key (str): Sort key
+        """
+        with open(file, "r") as f:
+            reader = csv.DictReader(f)
+            headers = reader.fieldnames
+            if partition_key not in headers:
+                raise InvalidParameter(
+                    f"Partition key '{partition_key}' not found in CSV headers of file: {file}"
+                )
+            if sort_key and sort_key not in headers:
+                raise InvalidParameter(
+                    f"Sort key '{sort_key}' not found in CSV headers of file: {file}"
+                )
+
+            with table.batch_writer() as batch:
+                for row in reader:
+                    batch.put_item(Item=row)
+
+    def _write_jsonl_to_dynamodb(self, file, table, partition_key, sort_key):
+        """Write JSONL file to DynamoDB
+        Args:
+            file (str): File path
+            table (boto3.resources.factory.dynamodb.Table): DynamoDB table
+            partition_key (str): Partition key
+            sort_key (str): Sort key
+        """
+        with open(file, "r") as f:
+            with table.batch_writer() as batch:
+                for line_number, line in enumerate(f, 1):
+                    try:
+                        item = json.loads(line)
+                    except json.JSONDecodeError as e:
+                        raise InvalidFormat(
+                            f"Invalid JSON format in file {file} at line {line_number}: {str(e)}"
+                        )
+
+                    if partition_key not in item:
+                        raise InvalidParameter(
+                            f"Partition key '{partition_key}' not found in JSONL file: {file} at line {line_number}"
+                        )
+                    if sort_key and sort_key not in item:
+                        raise InvalidParameter(
+                            f"Sort key '{sort_key}' not found in JSONL file: {file} at line {line_number}"
+                        )
+                    batch.put_item(Item=item)

--- a/cliboa/scenario/load/aws.py
+++ b/cliboa/scenario/load/aws.py
@@ -186,10 +186,12 @@ class DynamoDBWrite(BaseAws):
 
                     if partition_key not in item:
                         raise InvalidParameter(
-                            f"Partition key '{partition_key}' not found in JSONL file: {file} at line {line_number}"
+                            f"Partition key '{partition_key}' not found in JSONL file: "
+                            f"{file} at line {line_number}"
                         )
                     if sort_key and sort_key not in item:
                         raise InvalidParameter(
-                            f"Sort key '{sort_key}' not found in JSONL file: {file} at line {line_number}"
+                            f"Sort key '{sort_key}' not found in JSONL file: "
+                            f"{file} at line {line_number}"
                         )
                     batch.put_item(Item=item)

--- a/cliboa/test/scenario/load/test_aws.py
+++ b/cliboa/test/scenario/load/test_aws.py
@@ -1,0 +1,207 @@
+#
+# Copyright BrainPad Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+
+
+import csv
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from cliboa.scenario.load.aws import DynamoDBWrite
+from cliboa.test import BaseCliboaTest
+from cliboa.util.exception import FileNotFound, InvalidFormat, InvalidParameter
+from cliboa.util.helper import Helper
+from cliboa.util.lisboa_log import LisboaLog
+
+
+class TestDynamoDBWrite(BaseCliboaTest):
+    def _get_dynamodb_write_instance(self, file_format):
+        instance = DynamoDBWrite()
+        Helper.set_property(instance, "table_name", "test_table")
+        Helper.set_property(instance, "src_dir", "/test/dir")
+        Helper.set_property(instance, "src_pattern", "test*")
+        Helper.set_property(instance, "file_format", file_format)
+        Helper.set_property(instance, "region", "us-west-2")
+        Helper.set_property(instance, "logger", LisboaLog.get_logger(__name__))
+        return instance
+
+    @patch("cliboa.scenario.load.aws.BaseAws.get_target_files")
+    def test_file_not_found(self, mock_get_target_files):
+        mock_get_target_files.return_value = []
+        with pytest.raises(FileNotFound):
+            dynamodb_write = self._get_dynamodb_write_instance("csv")
+            dynamodb_write.execute()
+
+    @patch("boto3.resource")
+    @patch("cliboa.scenario.load.aws.BaseAws.get_target_files")
+    def test_table_not_found(self, mock_get_target_files, mock_boto3_resource):
+        mock_get_target_files.return_value = ["/test/dir/test.csv"]
+        mock_table = MagicMock()
+        mock_boto3_resource.return_value.Table.return_value = mock_table
+        mock_boto3_resource.return_value.meta.client.exceptions.ResourceNotFoundException = (
+            ClientError
+        )
+        mock_table.load.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "Table not found"}},
+            "LoadTable",
+        )
+
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb_write = self._get_dynamodb_write_instance("csv")
+            dynamodb_write.execute()
+
+        assert exc_info.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+    @patch("boto3.resource")
+    @patch("cliboa.scenario.load.aws.BaseAws.get_target_files")
+    def test_csv_success(self, mock_get_target_files, mock_boto3_resource):
+        mock_table = MagicMock()
+        mock_boto3_resource.return_value.Table.return_value = mock_table
+        mock_table.key_schema = [{"AttributeName": "id", "KeyType": "HASH"}]
+
+        csv_content = "id,name\n1,test1\n2,test2"
+        with tempfile.NamedTemporaryFile(mode="w", delete=True) as temp_file:
+            temp_file.write(csv_content)
+            temp_file.flush()
+            mock_get_target_files.return_value = [temp_file.name]
+
+            dynamodb_write = self._get_dynamodb_write_instance("csv")
+            dynamodb_write.execute()
+
+        mock_table.batch_writer.assert_called_once()
+        mock_table.batch_writer().__enter__().put_item.assert_any_call(
+            Item={"id": "1", "name": "test1"}
+        )
+        mock_table.batch_writer().__enter__().put_item.assert_any_call(
+            Item={"id": "2", "name": "test2"}
+        )
+
+    @patch("boto3.resource")
+    @patch("cliboa.scenario.load.aws.BaseAws.get_target_files")
+    def test_jsonl_success(self, mock_get_target_files, mock_boto3_resource):
+        mock_table = MagicMock()
+        mock_boto3_resource.return_value.Table.return_value = mock_table
+        mock_table.key_schema = [{"AttributeName": "id", "KeyType": "HASH"}]
+
+        jsonl_content = '{"id": "1", "name": "test1"}\n{"id": "2", "name": "test2"}'
+        with tempfile.NamedTemporaryFile(mode="w", delete=True) as temp_file:
+            temp_file.write(jsonl_content)
+            temp_file.flush()
+            mock_get_target_files.return_value = [temp_file.name]
+            dynamodb_write = self._get_dynamodb_write_instance("jsonl")
+            dynamodb_write.execute()
+
+        mock_table.batch_writer.assert_called_once()
+        mock_table.batch_writer().__enter__().put_item.assert_any_call(
+            Item={"id": "1", "name": "test1"}
+        )
+        mock_table.batch_writer().__enter__().put_item.assert_any_call(
+            Item={"id": "2", "name": "test2"}
+        )
+
+    @patch("boto3.resource")
+    @patch("cliboa.scenario.load.aws.BaseAws.get_target_files")
+    def test_csv_format_error(self, mock_get_target_files, mock_boto3_resource):
+        mock_table = MagicMock()
+        mock_boto3_resource.return_value.Table.return_value = mock_table
+        mock_table.key_schema = [{"AttributeName": "id", "KeyType": "HASH"}]
+
+        csv_content = "id_dehanai,name\n1,test1\n2,test2,extra"
+        with tempfile.NamedTemporaryFile(mode="w", delete=True) as temp_file:
+            temp_file.write(csv_content)
+            temp_file.flush()
+            mock_get_target_files.return_value = [temp_file.name]
+
+            with pytest.raises(InvalidParameter):
+                dynamodb_write = self._get_dynamodb_write_instance("csv")
+                dynamodb_write.execute()
+
+    @patch("boto3.resource")
+    @patch("cliboa.scenario.load.aws.BaseAws.get_target_files")
+    def test_jsonl_format_error(self, mock_get_target_files, mock_boto3_resource):
+        mock_table = MagicMock()
+        mock_boto3_resource.return_value.Table.return_value = mock_table
+        mock_table.key_schema = [{"AttributeName": "id", "KeyType": "HASH"}]
+
+        jsonl_content = '{"id": "1", "name": "test1"}\n{"id": "2", "name": "test2",}'
+        with tempfile.NamedTemporaryFile(mode="w", delete=True) as temp_file:
+            temp_file.write(jsonl_content)
+            temp_file.flush()
+            mock_get_target_files.return_value = [temp_file.name]
+
+            with pytest.raises(InvalidFormat):
+                dynamodb_write = self._get_dynamodb_write_instance("jsonl")
+                dynamodb_write.execute()
+
+    @patch("boto3.resource")
+    @patch("cliboa.scenario.load.aws.BaseAws.get_target_files")
+    def test_execute_csv_with_sort_key(self, mock_get_target_files, mock_boto3_resource):
+        mock_table = MagicMock()
+        mock_boto3_resource.return_value.Table.return_value = mock_table
+        mock_table.key_schema = [
+            {"AttributeName": "id", "KeyType": "HASH"},
+            {"AttributeName": "timestamp", "KeyType": "RANGE"},
+        ]
+
+        csv_content = "id,name,timestamp\n1,test1,2023-01-01\n2,test2,2023-01-02"
+        with tempfile.NamedTemporaryFile(mode="w", delete=True) as temp_file:
+            temp_file.write(csv_content)
+            temp_file.flush()
+            mock_get_target_files.return_value = [temp_file.name]
+
+            # test
+            dynamodb_write = self._get_dynamodb_write_instance("csv")
+            dynamodb_write.execute()
+
+        # assert
+        mock_table.batch_writer.assert_called_once()
+        mock_table.batch_writer().__enter__().put_item.assert_any_call(
+            Item={"id": "1", "name": "test1", "timestamp": "2023-01-01"}
+        )
+        mock_table.batch_writer().__enter__().put_item.assert_any_call(
+            Item={"id": "2", "name": "test2", "timestamp": "2023-01-02"}
+        )
+
+    @patch("boto3.resource")
+    @patch("cliboa.scenario.load.aws.BaseAws.get_target_files")
+    def test_execute_jsonl_with_sort_key(self, mock_get_target_files, mock_boto3_resource):
+        mock_table = MagicMock()
+        mock_boto3_resource.return_value.Table.return_value = mock_table
+        mock_table.key_schema = [
+            {"AttributeName": "id", "KeyType": "HASH"},
+            {"AttributeName": "timestamp", "KeyType": "RANGE"},
+        ]
+
+        jsonl_content = '{"id": "1", "name": "test1", "timestamp": "2023-01-01"}\n{"id": "2", "name": "test2", "timestamp": "2023-01-02"}'
+        with tempfile.NamedTemporaryFile(mode="w", delete=True) as temp_file:
+            temp_file.write(jsonl_content)
+            temp_file.flush()
+            mock_get_target_files.return_value = [temp_file.name]
+
+            # test
+            dynamodb_write = self._get_dynamodb_write_instance("jsonl")
+            dynamodb_write.execute()
+
+        # assert
+        mock_table.batch_writer.assert_called_once()
+        mock_table.batch_writer().__enter__().put_item.assert_any_call(
+            Item={"id": "1", "name": "test1", "timestamp": "2023-01-01"}
+        )
+        mock_table.batch_writer().__enter__().put_item.assert_any_call(
+            Item={"id": "2", "name": "test2", "timestamp": "2023-01-02"}
+        )

--- a/cliboa/test/scenario/load/test_aws.py
+++ b/cliboa/test/scenario/load/test_aws.py
@@ -107,10 +107,10 @@ class TestDynamoDBWrite(BaseCliboaTest):
 
         mock_table.batch_writer.assert_called_once()
         mock_table.batch_writer().__enter__().put_item.assert_any_call(
-            Item={"id": "1", "name": "test1"}
+            Item={"id": "1", "name": "test1", "timestamp": "2023-01-01"}
         )
         mock_table.batch_writer().__enter__().put_item.assert_any_call(
-            Item={"id": "2", "name": "test2"}
+            Item={"id": "2", "name": "test2", "timestamp": "2023-01-02"}
         )
 
     @patch("boto3.resource")

--- a/cliboa/test/scenario/load/test_aws.py
+++ b/cliboa/test/scenario/load/test_aws.py
@@ -12,10 +12,6 @@
 # all copies or substantial portions of the Software.
 #
 
-
-import csv
-import json
-import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
@@ -98,7 +94,10 @@ class TestDynamoDBWrite(BaseCliboaTest):
         mock_boto3_resource.return_value.Table.return_value = mock_table
         mock_table.key_schema = [{"AttributeName": "id", "KeyType": "HASH"}]
 
-        jsonl_content = '{"id": "1", "name": "test1"}\n{"id": "2", "name": "test2"}'
+        jsonl_content = (
+            '{"id": "1", "name": "test1", "timestamp": "2023-01-01"}\n'
+            '{"id": "2", "name": "test2", "timestamp": "2023-01-02"}'
+        )
         with tempfile.NamedTemporaryFile(mode="w", delete=True) as temp_file:
             temp_file.write(jsonl_content)
             temp_file.flush()
@@ -187,7 +186,10 @@ class TestDynamoDBWrite(BaseCliboaTest):
             {"AttributeName": "timestamp", "KeyType": "RANGE"},
         ]
 
-        jsonl_content = '{"id": "1", "name": "test1", "timestamp": "2023-01-01"}\n{"id": "2", "name": "test2", "timestamp": "2023-01-02"}'
+        jsonl_content = (
+            '{"id": "1", "name": "test1", "timestamp": "2023-01-01"}\n'
+            '{"id": "2", "name": "test2", "timestamp": "2023-01-02"}'
+        )
         with tempfile.NamedTemporaryFile(mode="w", delete=True) as temp_file:
             temp_file.write(jsonl_content)
             temp_file.flush()

--- a/docs/default_etl_modules.md
+++ b/docs/default_etl_modules.md
@@ -44,6 +44,7 @@ Can use ETL modules as below by default.
 |----------|-----------|
 |[AzureBlobUpload](/docs/modules/azureblob_upload.md)|Upload files to Azure Blob Storage|
 |[BigQueryWrite](/docs/modules/bigquery_write.md)|Read content from a file and insert it into a table of bigquery|
+|[DynamoDBWrite](/docs/modules/dynamodb_write.md)|Write data to Amazon DynamoDB table|
 |[FirestoreDocumentCreate](/docs/modules/firestore_document_create.md)|Create document|
 |[GcsUpload](/docs/modules/gcs_upload.md)|Upload files to GCS|
 |[SftpUpload](/docs/modules/sftp_upload.md)|Upload a file via sftp|

--- a/docs/modules/dynamodb_write.md
+++ b/docs/modules/dynamodb_write.md
@@ -1,0 +1,41 @@
+# DynamoDBWrite
+Writes data to a DynamoDB table.
+
+# Parameters
+|Parameter|Description|Required|Default|Remarks|
+|---------|-----------|--------|-------|-------|
+|table_name|DynamoDB table name|Yes|None||
+|src_dir|Path of the directory which target files are placed|Yes|None||
+|src_pattern|Regex which is to find target files|Yes|None||
+|file_format|input file format|No|"csv"|Can be either "csv" or "jsonl".|
+|region|AWS region|No|None|If not specified, the default region will be used.|
+|access_key|AWS access key|No|None|If not specified, environment variables or IAM role will be used.|
+|secret_key|AWS secret key|No|None|If not specified, environment variables or IAM role will be used.|
+|profile|AWS profile|No|None|Section name of ~/.aws/config|
+
+# Example
+```yaml
+scenario:
+  step:
+    class: DynamoDBWrite
+    arguments:
+      table_name: your_dynamodb_table
+      src_dir: /path/to/source
+      src_pattern: "*.csv"
+      file_format: csv
+```
+
+
+# Notes
+
+1. CSV files must have a header row. The header names will be used as attribute names in DynamoDB.
+
+2. There is no data type conversion option. When reading from CSV files, all values are treated as strings, which may not be ideal for numeric or boolean data in DynamoDB.
+
+3. The module currently only supports the standard write mode. Transactional writes are not supported.
+
+4. There is no support for conditional writes. It's not possible to specify conditions when overwriting existing items.
+
+5. For JSONL files, each line must be a valid JSON object, and the keys in these objects will be used as attribute names in DynamoDB.
+
+These limitations may be addressed in future versions of the module.


### PR DESCRIPTION
## Summary ##
Add functionality to write data from CSV or JSONL files to DynamoDB tables

## Key features ##
- Specify input file path, table name, and file format
- Support for CSV and JSONL input formats

This commit enables users to efficiently import data into DynamoDB tables from CSV or JSONL files.

## Brief ##
This PR adds a new feature to write data from CSV or JSONL files to DynamoDB tables. Key features include:

User-specifiable parameters:
- Input file path
- Table name
- File format (CSV or JSONL)

Supported input formats:
- CSV
- JSONL

The implementation uses batch write operations to efficiently insert data into the DynamoDB table. This feature addition enables users to import datasets into DynamoDB tables from common file formats.

## Points to Check ##
* Is the current approach to exception handling and logging consistent with other parts of the project? Should we enhance error reporting?
* Are there any implementation aspects missing from this OSS implementation? Please check if I've overlooked any considerations, particularly regarding data consistency or performance during writes.
* Does this implementation align with the style of this OSS project?

### Test ###
Confirming

### Review Limit ###
* `None`

Additional Information:
In the current implementation, we're focusing on basic write operations. For future enhancements, we could consider:
- Adding support for updating existing items in the table
- Implementing a feature to map CSV/JSONL fields to specific DynamoDB attributes
- Adding options for handling duplicate keys or other write conflicts