### PR TITLE
[WIP]fix a deploy logic

### DIFF
--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -9,7 +9,7 @@ on:
       pypi_token:
         description: PyPI token
         required: true
-        default: ""
+        default: "spam"
 
 jobs:
   deploy_to_pypi:

--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -6,7 +6,7 @@ on:
       - "449" # debug
   workflow_dispatch:
     inputs:
-      pypi_token:
+      token:
         description: PyPI token
         required: true
         default: "spam"
@@ -30,7 +30,7 @@ jobs:
       - name: upload to pypi
         run: |
           # fetch a pypi token
-          PYPI_TOKEN=jq -r '.inputs.pypi_token' $GITHUB_EVENT_PATH`
+          PYPI_TOKEN=jq -r '.inputs.token' $GITHUB_EVENT_PATH`
           echo ::add-mask::$PYPI_TOKEN
           # upload a python package to pypi
           sudo python3 -m twine upload --repository pypi dist/* -u "__token__" -p $PYPI_TOKEN

--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: upload to pypi
         run: |
           # fetch a pypi token
-          PYPI_TOKEN=jq -r '.inputs.token' $GITHUB_EVENT_PATH`
+          PYPI_TOKEN=`jq -r '.inputs.token' $GITHUB_EVENT_PATH`
           echo ::add-mask::$PYPI_TOKEN
           # upload a python package to pypi
           sudo python3 -m twine upload --repository pypi dist/* -u "__token__" -p $PYPI_TOKEN

--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -3,7 +3,7 @@ name: cliboa-deploy
 on:
   push:
     branches:
-      - "449" # debug
+      - "224" # debug
   workflow_dispatch:
     inputs:
       token:

--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -3,7 +3,7 @@ name: cliboa-deploy
 on:
   push:
     branches:
-      - "223" # debug
+      - "449" # debug
   workflow_dispatch:
     inputs:
       pypi_token:

--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -6,17 +6,9 @@ on:
       - "223" # debug
   workflow_dispatch:
     inputs:
-      username:
-        description: PyPI username
+      pypi_token:
+        description: PyPI token
         required: true
-        default: "spam"
-      password:
-        description: PyPI password
-        required: true
-        default: "spam"
-      is_test:
-        description: if upload pypi test repository
-        required: false
         default: ""
 
 jobs:
@@ -27,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: install dependencies
         run: |
           sudo python3 -m pip install twine
@@ -37,9 +29,8 @@ jobs:
           sudo python3 setup.py sdist bdist_wheel
       - name: upload to pypi
         run: |
-          # upload to pypi
-          PYPI_USERNAME=`jq -r '.inputs.username' $GITHUB_EVENT_PATH`
-          PYPI_PASSWORD=`jq -r '.inputs.password' $GITHUB_EVENT_PATH`
-          echo ::add-mask::$PYPI_USERNAME
-          echo ::add-mask::$PYPI_PASSWORD
-          sudo python3 tools/script/deploy_to_pypi.py $PYPI_USERNAME $PYPI_PASSWORD "${{ github.event.inputs.is_test }}"
+          # fetch a pypi token
+          PYPI_TOKEN=jq -r '.inputs.pypi_token' $GITHUB_EVENT_PATH`
+          echo ::add-mask::$PYPI_TOKEN
+          # upload a python package to pypi
+          sudo python3 -m twine upload --repository pypi dist/* -u "__token__" -p $PYPI_TOKEN

--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: 3.9
       - name: install dependencies
         run: |
           sudo python3 -m pip install twine


### PR DESCRIPTION
## Brief ##

pypiへのcliboaパッケージのアップロードをトークンベースのロジックに修正

## Points to Check ##
* github actionsのupload_pypi.yamlの内容

### Test ###
Confirmed

ダミーのトークンでpypiへのアップロードが失敗するところまで確認済み
[](https://github.com/BrainPad/cliboa/actions/runs/12644100887/job/35231128509)

成功テストはトークンをupload_pypi.yamlにハードコードする必要があるため実施しない。mainにマージされた後、GitHubActionsから手動で実行予定

（Write content to confirm / Reason why not necessary）

### Review Limit ###
* `Write review limit on pull request title.`
