### PR TITLE
#485 Add workflow to automatically label stale issues and PRs.(due 2025/09/30)

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,27 @@
+name: cliboa-stale
+
+on:
+  schedule:
+    - cron: '30 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Mark stale issues and pull requests
+        uses: actions/stale@v9
+        with:
+          days-before-stale: 365
+          days-before-close: -1
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It may be closed if no further activity occurs. Thank you for your contributions.'
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It may be closed if no further activity occurs. Thank you for your contributions.'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'no-stale'
+          exempt-issue-labels: 'no-stale'
+          operations-per-run: 100


### PR DESCRIPTION
## Brief ##

Implement issue #485

## Points to Check ##
* Please check if the CI implementation works as intended

### Test ###
Not necessary

Reason:
1. Testing this would apply the 'stale' label.
2. I am using a well-trusted action, which is known for its reliability.

### Review Limit ###
* `Write review limit on pull request title.`
