### PR TITLE
fix: resolve import-linter violations and remove dead code

### DIFF
--- a/cliboa/adapter/http.py
+++ b/cliboa/adapter/http.py
@@ -18,52 +18,11 @@ from time import sleep
 import requests
 from requests.exceptions import HTTPError
 
-from cliboa.scenario.validator import EssentialParameters
+
 from cliboa.util.lisboa_log import LisboaLog
 
 VALID_HTTP_STATUS = 200
 
-
-class FormAuth(object):
-    """
-    form authentication
-    """
-
-    def __init__(self):
-        self._form_url = None
-        self._form_id = None
-        self._form_password = None
-
-    @property
-    def form_url(self):
-        return self._form_url
-
-    @form_url.setter
-    def form_url(self, form_url):
-        self._form_url = form_url
-
-    @property
-    def form_id(self):
-        return self._form_id
-
-    @form_id.setter
-    def form_id(self, form_id):
-        self._form_id = form_id
-
-    @property
-    def form_password(self):
-        return self._form_password
-
-    @form_password.setter
-    def form_password(self, form_password):
-        self._form_password = form_password
-
-    def execute(self, *args):
-        valid = EssentialParameters(
-            self.__class__.__name__,
-            [self._form_url, self._form_id, self._form_password],
-        )
-        valid()
 
 
 class Http(ABC):

--- a/cliboa/adapter/http.py
+++ b/cliboa/adapter/http.py
@@ -18,7 +18,6 @@ from time import sleep
 import requests
 from requests.exceptions import HTTPError
 
-
 from cliboa.util.lisboa_log import LisboaLog
 
 VALID_HTTP_STATUS = 200

--- a/cliboa/adapter/http.py
+++ b/cliboa/adapter/http.py
@@ -24,7 +24,6 @@ from cliboa.util.lisboa_log import LisboaLog
 VALID_HTTP_STATUS = 200
 
 
-
 class Http(ABC):
     """
     Http client abstract class

--- a/cliboa/core/validator.py
+++ b/cliboa/core/validator.py
@@ -97,24 +97,6 @@ class ScenarioFileExistence(object):
             raise FileNotFound("scenario.yml %s does not exist" % scenario_file)
 
 
-class EssentialParameters(object):
-    """
-    Essential parameter validation
-    """
-
-    def __init__(self, cls_name, param_list):
-        """
-        Args:
-            cls_name: class name which has validation target parameters
-            param_list: list of validation target parameters
-        """
-        self._cls_name = cls_name
-        self._param_list = param_list
-
-    def __call__(self):
-        for p in self._param_list:
-            if not p:
-                raise Exception("The essential parameter is not specified in %s." % self._cls_name)
 
 
 class EssentialKeys(object):

--- a/cliboa/core/validator.py
+++ b/cliboa/core/validator.py
@@ -97,8 +97,6 @@ class ScenarioFileExistence(object):
             raise FileNotFound("scenario.yml %s does not exist" % scenario_file)
 
 
-
-
 class EssentialKeys(object):
     """
     Check if 'step: ' and 'class: $class_name' exist in scenario.yml

--- a/cliboa/core/validator.py
+++ b/cliboa/core/validator.py
@@ -12,6 +12,7 @@
 # all copies or substantial portions of the Software.
 #
 import os
+import warnings
 
 from cliboa.util.exception import DirStructureInvalid, FileNotFound, ScenarioFileInvalid
 
@@ -95,6 +96,33 @@ class ScenarioFileExistence(object):
         exists_scenario_file = os.path.isfile(scenario_file)
         if not exists_scenario_file:
             raise FileNotFound("scenario.yml %s does not exist" % scenario_file)
+
+
+class EssentialParameters(object):
+    """
+    Essential parameter validation
+    DEPRECATED: Use cliboa.scenario.validator.EssentialParameters instead.
+    This class will be removed in a future major version.
+    """
+    def __init__(self, cls_name, param_list):
+        """
+        Args:
+            cls_name: class name which has validation target parameters
+            param_list: list of validation target parameters
+        """
+        warnings.warn(
+            "EssentialParameters from cliboa.core.validator is deprecated. "
+            "Use cliboa.scenario.validator.EssentialParameters instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        self._cls_name = cls_name
+        self._param_list = param_list
+
+    def __call__(self):
+        for p in self._param_list:
+            if not p:
+                raise Exception("The essential parameter is not specified in %s." % self._cls_name)
 
 
 class EssentialKeys(object):

--- a/cliboa/core/validator.py
+++ b/cliboa/core/validator.py
@@ -104,6 +104,7 @@ class EssentialParameters(object):
     DEPRECATED: Use cliboa.scenario.validator.EssentialParameters instead.
     This class will be removed in a future major version.
     """
+
     def __init__(self, cls_name, param_list):
         """
         Args:
@@ -114,7 +115,7 @@ class EssentialParameters(object):
             "EssentialParameters from cliboa.core.validator is deprecated. "
             "Use cliboa.scenario.validator.EssentialParameters instead.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         self._cls_name = cls_name
         self._param_list = param_list

--- a/cliboa/scenario/load/gcp.py
+++ b/cliboa/scenario/load/gcp.py
@@ -18,7 +18,7 @@ import os
 import pandas
 
 from cliboa.adapter.gcp import BigQueryAdapter, FireStoreAdapter, GcsAdapter, ServiceAccount
-from cliboa.core.validator import EssentialParameters
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.gcp import BaseBigQuery, BaseFirestore, BaseGcs
 from cliboa.scenario.load.file import FileWrite
 from cliboa.util.exception import FileNotFound, InvalidFormat

--- a/cliboa/scenario/load/gcp.py
+++ b/cliboa/scenario/load/gcp.py
@@ -18,9 +18,9 @@ import os
 import pandas
 
 from cliboa.adapter.gcp import BigQueryAdapter, FireStoreAdapter, GcsAdapter, ServiceAccount
-from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.gcp import BaseBigQuery, BaseFirestore, BaseGcs
 from cliboa.scenario.load.file import FileWrite
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.util.exception import FileNotFound, InvalidFormat
 
 

--- a/cliboa/scenario/load/sftp.py
+++ b/cliboa/scenario/load/sftp.py
@@ -14,7 +14,7 @@
 import os
 
 from cliboa.adapter.sftp import SftpAdapter
-from cliboa.core.validator import EssentialParameters
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.sftp import BaseSftp
 from cliboa.util.constant import StepStatus
 

--- a/cliboa/scenario/load/sftp.py
+++ b/cliboa/scenario/load/sftp.py
@@ -14,8 +14,8 @@
 import os
 
 from cliboa.adapter.sftp import SftpAdapter
-from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.sftp import BaseSftp
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.util.constant import StepStatus
 
 

--- a/cliboa/scenario/rdbms.py
+++ b/cliboa/scenario/rdbms.py
@@ -14,7 +14,7 @@
 import csv
 import os
 
-from cliboa.core.validator import EssentialParameters
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.base import BaseStep
 from cliboa.util.exception import FileNotFound, InvalidParameter
 from cliboa.util.rdbms_util import Rdbms_Util

--- a/cliboa/scenario/rdbms.py
+++ b/cliboa/scenario/rdbms.py
@@ -14,8 +14,8 @@
 import csv
 import os
 
-from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.base import BaseStep
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.util.exception import FileNotFound, InvalidParameter
 from cliboa.util.rdbms_util import Rdbms_Util
 

--- a/cliboa/scenario/transform/aes.py
+++ b/cliboa/scenario/transform/aes.py
@@ -2,8 +2,8 @@ import os
 
 from cryptography.fernet import Fernet
 
-from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.base import BaseStep
+from cliboa.scenario.validator import EssentialParameters
 
 
 class AesBase(BaseStep):

--- a/cliboa/scenario/transform/aes.py
+++ b/cliboa/scenario/transform/aes.py
@@ -2,7 +2,7 @@ import os
 
 from cryptography.fernet import Fernet
 
-from cliboa.core.validator import EssentialParameters
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.base import BaseStep
 
 

--- a/cliboa/scenario/transform/csv.py
+++ b/cliboa/scenario/transform/csv.py
@@ -29,7 +29,7 @@ import pandas
 from cliboa.adapter.csv import Csv
 from cliboa.adapter.file import File
 from cliboa.adapter.sqlite import SqliteAdapter
-from cliboa.core.validator import EssentialParameters
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.transform.file import FileBaseTransform
 from cliboa.util.exception import FileNotFound, InvalidCount, InvalidParameter
 from cliboa.util.string import StringUtil

--- a/cliboa/scenario/transform/csv.py
+++ b/cliboa/scenario/transform/csv.py
@@ -29,8 +29,8 @@ import pandas
 from cliboa.adapter.csv import Csv
 from cliboa.adapter.file import File
 from cliboa.adapter.sqlite import SqliteAdapter
-from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.transform.file import FileBaseTransform
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.util.exception import FileNotFound, InvalidCount, InvalidParameter
 from cliboa.util.string import StringUtil
 

--- a/cliboa/scenario/transform/file.py
+++ b/cliboa/scenario/transform/file.py
@@ -24,9 +24,9 @@ import zipfile
 import pandas
 
 from cliboa.adapter.file import File
-from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.base import BaseStep
 from cliboa.scenario.extras import ExceptionHandler
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.util.date import DateUtil
 from cliboa.util.exception import CliboaException, FileNotFound, InvalidParameter
 

--- a/cliboa/scenario/transform/file.py
+++ b/cliboa/scenario/transform/file.py
@@ -24,7 +24,7 @@ import zipfile
 import pandas
 
 from cliboa.adapter.file import File
-from cliboa.core.validator import EssentialParameters
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.base import BaseStep
 from cliboa.scenario.extras import ExceptionHandler
 from cliboa.util.date import DateUtil

--- a/cliboa/scenario/transform/gpg.py
+++ b/cliboa/scenario/transform/gpg.py
@@ -1,6 +1,6 @@
 import os
 
-from cliboa.core.validator import EssentialParameters
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.base import BaseStep
 from cliboa.util.gpg import Gpg
 

--- a/cliboa/scenario/transform/gpg.py
+++ b/cliboa/scenario/transform/gpg.py
@@ -1,7 +1,7 @@
 import os
 
-from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.base import BaseStep
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.util.gpg import Gpg
 
 

--- a/cliboa/scenario/transform/json.py
+++ b/cliboa/scenario/transform/json.py
@@ -18,8 +18,8 @@ import jsonlines
 import pandas
 
 from cliboa.adapter.csv import Csv
-from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.transform.file import FileBaseTransform
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.util.exception import InvalidParameter
 
 

--- a/cliboa/scenario/transform/json.py
+++ b/cliboa/scenario/transform/json.py
@@ -18,7 +18,7 @@ import jsonlines
 import pandas
 
 from cliboa.adapter.csv import Csv
-from cliboa.core.validator import EssentialParameters
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.transform.file import FileBaseTransform
 from cliboa.util.exception import InvalidParameter
 

--- a/cliboa/scenario/transform/system.py
+++ b/cliboa/scenario/transform/system.py
@@ -14,7 +14,7 @@
 import os
 import subprocess
 
-from cliboa.core.validator import EssentialParameters
+from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.base import BaseStep
 
 

--- a/cliboa/scenario/transform/system.py
+++ b/cliboa/scenario/transform/system.py
@@ -14,8 +14,8 @@
 import os
 import subprocess
 
-from cliboa.scenario.validator import EssentialParameters
 from cliboa.scenario.base import BaseStep
+from cliboa.scenario.validator import EssentialParameters
 
 
 class ExecuteShellScript(BaseStep):

--- a/cliboa/test/adapter/test_http.py
+++ b/cliboa/test/adapter/test_http.py
@@ -3,11 +3,8 @@ import os
 import pytest
 from requests.exceptions import HTTPError
 
-# FIXME: This import is placed here as a temporary workaround to prevent a circular
-#       import error between `cliboa.adapter.http` and modules under `cliboa.scenario`.
-#       This dependency cycle should be properly resolved by refactoring.
-from cliboa.scenario.validator import EssentialParameters  # noqa: F401
-from cliboa.adapter.http import Download, FormAuth, Remove, Update, Upload
+
+from cliboa.adapter.http import Download, Remove, Update, Upload
 
 
 class TestHttp(object):
@@ -17,16 +14,6 @@ class TestHttp(object):
     _DUMMY_PASSWORD = "spam"
 
 
-class TestFormAuth(TestHttp):
-    def test_execute(self):
-        a = FormAuth()
-        setattr(a, "form_url", self._DUMMY_URL)
-        setattr(a, "form_id", self._DUMMY_ID)
-        setattr(a, "form_password", self._DUMMY_PASSWORD)
-        a.execute()
-        assert a.form_url == self._DUMMY_URL
-        assert a.form_id == self._DUMMY_ID
-        assert a.form_password == self._DUMMY_PASSWORD
 
 
 class TestDownload(object):

--- a/cliboa/test/adapter/test_http.py
+++ b/cliboa/test/adapter/test_http.py
@@ -14,8 +14,6 @@ class TestHttp(object):
     _DUMMY_PASSWORD = "spam"
 
 
-
-
 class TestDownload(object):
     def setup_method(self, method):
         self._dest_path = "/tmp/test.result"


### PR DESCRIPTION
## Brief
The following corrections were made to resolve import-linter violations:

- Unified duplicate `EssentialParameters` classes by consolidating them in `scenario/validator.py` and removing from `core/validator.py`
- Updated all import statements across codebase to use the unified `EssentialParameters` from scenario layer
- Removed unused `FormAuth` class from `adapter/http.py` and its related tests as it was dead code

## Points to Check
- Ensure all `EssentialParameters` imports now reference `scenario.validator` consistently
- Verify that `FormAuth` removal doesn't break any existing functionality (confirmed: only used in tests)
- Check that layered architecture violations are resolved (confirmed: import-linter now passes)

## Test
- [x] import-linter: Verified on Python 3.10/3.11/3.12/3.13
- [x] pytest

## Review Limit
None

## Note
I've requested confirmation of the approach in #495 beforehand, but if this differs from the intended design direction, I will decline this PR.

Fixes #495