### PR TITLE
Update CsvRowDelete documentation to accurately reflect filtering behavior

### DIFF
--- a/docs/modules/csv_row_delete.md
+++ b/docs/modules/csv_row_delete.md
@@ -1,5 +1,5 @@
 # CsvRowDelete
-Delete specific rows from csv files.
+Filter CSV rows by comparing key column values between source and reference CSV files. Rows are kept or deleted based on whether their key values exist in the reference file.
 
 # Parameters
 | Parameters       | Explanation                                                                                                                 | Required | Default | Remarks |


### PR DESCRIPTION
Fix misleading documentation that oversimplified CsvRowDelete as simple row deletion. The module actually performs CSV row filtering by comparing key column values between source and reference files, not straightforward row deletion.

Resolves #490

🤖 Generated with [Claude Code](https://claude.ai/code)

## Brief ##

Write here

## Points to Check ##
* Is the content correct?

### Test ###
Not necessary

（Write content to confirm / Reason why not necessary）

### Review Limit ###
* `Please watch it when you have time.`
