### PR TITLE
refactor: Update BaseStep to log properties in JSON format

### DIFF
--- a/cliboa/scenario/base.py
+++ b/cliboa/scenario/base.py
@@ -12,6 +12,7 @@
 # all copies or substantial portions of the Software.
 #
 import configparser
+import json
 import os
 import re
 import tempfile
@@ -63,11 +64,15 @@ class BaseStep(object):
             except Exception as e:
                 self._logger.warning(e)
 
+        props_dict = {}
         for k, v in self.__dict__.items():
             if mask is not None and pattern.search(k):
-                self._logger.info("%s : ****" % k)
+                props_dict[k] = "****"
             else:
-                self._logger.info("%s : %s" % (k, v))
+                props_dict[k] = v
+        self._logger.info(
+            "Step properties: %s" % json.dumps(props_dict, ensure_ascii=False, default=str)
+        )
         try:
             for listener in self._listeners:
                 listener.before_step(self)


### PR DESCRIPTION
## Brief
Changed BaseStep property logging from individual key-value pairs to unified JSON format.

- Replaced individual `self._logger.info("%s : %s" % (k, v))` calls with single JSON output
- Maintains existing mask functionality for sensitive data

## Points to Check
- Verify JSON format is properly output instead of individual key-value lines
- Ensure sensitive data masking still works with `****` replacement

## Test
- [x] Verified JSON format output and masking behavior
- [x] Confirmed structured JSON logging:
```
2025-09-03 23:17:56,088 MainProcess INFO base.py:73 Step properties: {"_step": "file_rename_test", "_symbol": null, "_parallel": null, "_logger": "<Logger FileRename (INFO)>", "_listeners": ["<cliboa.core.listener.StepStatusListener object at 0x147399ff0>"], "_src_dir": "/Users/nasubee/Project/cliboa/project", "_src_pattern": "(.*)\\.yml", "_dest_dir": null, "_dest_name": null, "_encoding": "utf-8", "_nonfile_error": false, "_force_continue": false, "_prefix": "test_", "_suffix": "_backup", "_regex_pattern": null, "_rep_str": null, "_ext": "", "_without_ext": true}
```

## Review Limit
None

## Note
Updated test implementation to use mock-based verification instead of log file parsing, as existing tests were incorrectly passing locally due to log files not being reset between test runs.

Fixes #506