### PR TITLE
Added group mode to CsvConcat.

### DIFF
--- a/cliboa/scenario/transform/csv.py
+++ b/cliboa/scenario/transform/csv.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 from datetime import datetime
+from functools import cached_property
 from typing import Literal, Set, Tuple
 
 import dask.dataframe as dask_df
@@ -31,7 +32,7 @@ from cliboa.adapter.sqlite import SqliteAdapter
 from cliboa.scenario.transform.file import FileBaseTransform
 from cliboa.scenario.validator import EssentialParameters
 from cliboa.util.base import _BaseObject  # _warn_deprecated_args
-from cliboa.util.exception import FileNotFound, InvalidCount, InvalidParameter
+from cliboa.util.exception import CliboaException, FileNotFound, InvalidCount, InvalidParameter
 from cliboa.util.string import StringUtil
 
 
@@ -533,9 +534,10 @@ class CsvConcat(FileBaseTransform):
         src_pattern: str | None = None
         src_filenames: list[str] | None = None
         dest_dir: str
-        dest_name: str
+        mode: Literal["all", "group"] = "all"
 
         @model_validator(mode="before")
+        @classmethod
         def check_exclusive_fields(cls, data: dict) -> dict:
             if not isinstance(data, dict):
                 raise ValueError(f"arguments is not dict: {data}")
@@ -548,7 +550,29 @@ class CsvConcat(FileBaseTransform):
                 )
             elif pattern_present and filenames_present:
                 raise InvalidParameter("Cannot specify both 'src_pattern' and 'src_filenames'.")
+
+            if data.get("mode", "all") == "group" and filenames_present:
+                raise InvalidParameter("Cannot specify 'src_filenames' when mode is 'group'.")
             return data
+
+        @model_validator(mode="after")
+        def validate_mode_dest_name_and_pattern(self) -> "CsvConcat.Arguments":
+            if self.mode == "all":
+                if not self.dest_name:
+                    raise InvalidParameter("dest_name is required when mode is 'all'.")
+            elif self.mode == "group":
+                if self.dest_name is not None:
+                    raise InvalidParameter("dest_name must not be specified when mode is 'group'.")
+                if self.src_compiled_pattern.groups < 1:
+                    raise InvalidParameter(
+                        "src_pattern must contain at least one capturing group"
+                        " when mode is 'group'."
+                    )
+            return self
+
+        @cached_property
+        def src_compiled_pattern(self) -> re.Pattern:
+            return re.compile(self.src_pattern)
 
     def execute(self, *args):
         if self.args.src_pattern:
@@ -564,6 +588,14 @@ class CsvConcat(FileBaseTransform):
             self.logger.warning("Two or more input files are required.")
 
         # Create output headers to conform to the concat specification.
+        if self.args.mode == "all":
+            self._concat_files(files, self.args.dest_name)
+        elif self.args.mode == "group":
+            grouped_files = self._group_files(files)
+            for dest_name, group_files in grouped_files.items():
+                self._concat_files(group_files, dest_name)
+
+    def _concat_files(self, files: list[str], dest_name: str) -> None:
         file_1 = files[0]
         output_header = pandas.read_csv(
             file_1, dtype=str, encoding=self.args.encoding, nrows=0, na_filter=False
@@ -577,10 +609,14 @@ class CsvConcat(FileBaseTransform):
                     ),
                 ]
             )
+        chunk_size_handling(
+            self._read_csv_func,
+            files,
+            output_header,
+            os.path.join(self.args.resolve_dest_dir(), dest_name),
+        )
 
-        chunk_size_handling(self._read_csv_func, files, output_header)
-
-    def _read_csv_func(self, chunksize, files, output_header):
+    def _read_csv_func(self, chunksize, files, output_header, dest_path: str):
         # Used in chunk_size_handling
         first_write = True
         for file in files:
@@ -595,13 +631,43 @@ class CsvConcat(FileBaseTransform):
                 # Change the header order to the one you plan to output.
                 df = pandas.concat([output_header, df])
                 df.to_csv(
-                    os.path.join(self.args.resolve_dest_dir(), self.args.dest_name),
+                    dest_path,
                     encoding=self.args.encoding,
                     header=True if first_write else False,
                     index=False,
                     mode="w" if first_write else "a",
                 )
                 first_write = False
+
+    def _group_files(self, files: list[str]) -> dict[str, list[str]]:
+        grouped_files: dict[str, list[str]] = {}
+        for path in files:
+            basename = os.path.basename(path)
+            dest_basename = self._build_grouped_dest_basename(basename)
+            grouped_files.setdefault(dest_basename, []).append(path)
+        return grouped_files
+
+    def _build_grouped_dest_basename(self, basename: str) -> str:
+        # Build dest basename by concatenating capturing group substrings in group number order.
+        match = self.args.src_compiled_pattern.fullmatch(basename)
+        if not match:
+            raise CliboaException(
+                "File name %r does not fully match src_pattern %r."
+                % (basename, self.args.src_pattern)
+            )
+        last = match.lastindex or 0
+        parts: list[str] = []
+        for i in range(1, last + 1):
+            chunk = match.group(i)
+            if chunk is not None:
+                parts.append(chunk)
+        dest = "".join(parts)
+        if not dest:
+            raise CliboaException(
+                "Capturing groups yielded an empty output basename for file name %r"
+                " (src_pattern %r)." % (basename, self.args.src_pattern)
+            )
+        return dest
 
 
 class CsvConvert(FileBaseTransform):

--- a/docs/modules/csv_concat.md
+++ b/docs/modules/csv_concat.md
@@ -2,15 +2,19 @@
 Concat plural csv files into one.
 This class behaves exactly same with the method 'pandas.concat'.
 
+You can concatenate **all** matched files into a single output (`mode: all`, default), or **group** files by output basename derived from regex capturing groups (`mode: group`).
+
 # Parameters
 |Parameters|Explanation|Required|Default|Remarks|
 |----------|-----------|--------|-------|-------|
 |src_dir|Path of the directory which target files are placed.|Yes|None||
-|src_pattern|Regex which is to find target files.|Yes|None||
-|src_filenames|File names of source to concat.|No|None|Specify either src_pattern or src_filenames is essential.|
+|src_pattern|Regex which is to find target files.|Yes|None|Used as `fullmatch` against each file **name** (not the full path). With `mode: group`, the pattern must include at least one **capturing** group; see below.|
+|src_filenames|File names of source to concat.|No|None|Specify either `src_pattern` or `src_filenames`. Cannot be used with `mode: group`.|
 |dest_dir|Path of the directory which is for output files.|Yes|None|If a non-existent directory path is specified, the directory is automatically created.|
-|dest_name|Output file name|Yes|None||
+|dest_name|Output file name.|Conditional|None|Required when `mode` is `all`. Must **not** be set when `mode` is `group` (output names come from `src_pattern`).|
+|mode|How inputs are combined.|No|`all`|`all`: merge every target file into one file named `dest_name`. `group`: split targets into groups that share the same derived output basename, then write one file per group.|
 |encoding|Character encoding when read and write|No|utf-8||
+
 
 # Examples
 ```
@@ -41,4 +45,19 @@ id, name
 2, two
 3, three
 4, four
+```
+
+## Group mode example
+```
+scenario:
+- step: Concat files by group
+  class: CsvConcat
+  arguments:
+    src_dir: /in
+    src_pattern: '^(.+_names)_\d+(\.csv)$'
+    dest_dir: /out
+    mode: group
+
+Input: /in/cat_names_00.csv, /in/cat_names_01.csv, /in/dog_names_00.csv
+Output: /out/cat_names.csv, /out/dog_names.csv
 ```

--- a/tests/scenario/transform/test_csv.py
+++ b/tests/scenario/transform/test_csv.py
@@ -1635,6 +1635,111 @@ class TestCsvConcat(TestCsvTransform):
             instance.execute()
         assert "Cannot specify both 'src_pattern' and 'src_filenames'." in str(execinfo.value)
 
+    def test_execute_group_mode_user_src_pattern(self):
+        # ^(.+_names)_\d+(\.csv)$ -> dest basename is group1 + group2 (e.g. cat_names + .csv)
+        cat_a = [["k", "v"], ["1", "a"]]
+        cat_b = [["k", "v"], ["2", "b"]]
+        dog_a = [["k", "v"], ["3", "c"]]
+        self._create_csv(cat_a, fname="cat_names_00.csv")
+        self._create_csv(cat_b, fname="cat_names_01.csv")
+        self._create_csv(dog_a, fname="dog_names_00.csv")
+
+        instance = CsvConcat()
+        instance._set_arguments(
+            {
+                "src_dir": self._data_dir,
+                "src_pattern": r"^(.+_names)_\d+(\.csv)$",
+                "dest_dir": self._data_dir,
+                "mode": "group",
+            }
+        )
+        instance.execute()
+
+        with open(os.path.join(self._data_dir, "cat_names.csv")) as t:
+            assert list(csv.reader(t)) == [["k", "v"], ["1", "a"], ["2", "b"]]
+        with open(os.path.join(self._data_dir, "dog_names.csv")) as t:
+            assert list(csv.reader(t)) == [["k", "v"], ["3", "c"]]
+
+    def test_execute_group_mode_non_capturing_suffix_pattern(self):
+        # (?:_\d+) drops the numeric suffix from captures; same outputs as user pattern.
+        cat_a = [["k", "v"], ["1", "a"]]
+        cat_b = [["k", "v"], ["2", "b"]]
+        dog_a = [["k", "v"], ["3", "c"]]
+        self._create_csv(cat_a, fname="cat_names_00.csv")
+        self._create_csv(cat_b, fname="cat_names_01.csv")
+        self._create_csv(dog_a, fname="dog_names_00.csv")
+
+        instance = CsvConcat()
+        instance._set_arguments(
+            {
+                "src_dir": self._data_dir,
+                "src_pattern": r"^(.+_names)(?:_\d+)(\.csv)$",
+                "dest_dir": self._data_dir,
+                "mode": "group",
+            }
+        )
+        instance.execute()
+
+        with open(os.path.join(self._data_dir, "cat_names.csv")) as t:
+            assert list(csv.reader(t)) == [["k", "v"], ["1", "a"], ["2", "b"]]
+        with open(os.path.join(self._data_dir, "dog_names.csv")) as t:
+            assert list(csv.reader(t)) == [["k", "v"], ["3", "c"]]
+
+    def test_execute_group_mode_three_groups(self):
+        cat_a = [["h", "x"], ["1", "ca"]]
+        cat_b = [["h", "x"], ["2", "cb"]]
+        dog_a = [["h", "x"], ["3", "d"]]
+        bird_a = [["h", "x"], ["4", "e"]]
+        bird_b = [["h", "x"], ["5", "f"]]
+        self._create_csv(cat_a, fname="cat_names_00.csv")
+        self._create_csv(cat_b, fname="cat_names_01.csv")
+        self._create_csv(dog_a, fname="dog_names_00.csv")
+        self._create_csv(bird_a, fname="bird_names_00.csv")
+        self._create_csv(bird_b, fname="bird_names_01.csv")
+
+        instance = CsvConcat()
+        instance._set_arguments(
+            {
+                "src_dir": self._data_dir,
+                "src_pattern": r"^(.+_names)(?:_\d+)(\.csv)$",
+                "dest_dir": self._data_dir,
+                "mode": "group",
+            }
+        )
+        instance.execute()
+
+        with open(os.path.join(self._data_dir, "cat_names.csv")) as t:
+            assert list(csv.reader(t)) == [["h", "x"], ["1", "ca"], ["2", "cb"]]
+        with open(os.path.join(self._data_dir, "dog_names.csv")) as t:
+            assert list(csv.reader(t)) == [["h", "x"], ["3", "d"]]
+        with open(os.path.join(self._data_dir, "bird_names.csv")) as t:
+            assert list(csv.reader(t)) == [["h", "x"], ["4", "e"], ["5", "f"]]
+
+    def test_execute_group_mode_nested_capturing_groups(self):
+        # ((.+)_names) nests (.+); dest is concat of all groups: cat_names + cat + .csv
+        cat_a = [["a", "b"], ["1", "x"]]
+        cat_b = [["a", "b"], ["2", "y"]]
+        dog_a = [["a", "b"], ["3", "z"]]
+        self._create_csv(cat_a, fname="cat_names_00.csv")
+        self._create_csv(cat_b, fname="cat_names_01.csv")
+        self._create_csv(dog_a, fname="dog_names_00.csv")
+
+        instance = CsvConcat()
+        instance._set_arguments(
+            {
+                "src_dir": self._data_dir,
+                "src_pattern": r"^((.+)_names)_\d+(\.csv)$",
+                "dest_dir": self._data_dir,
+                "mode": "group",
+            }
+        )
+        instance.execute()
+
+        with open(os.path.join(self._data_dir, "cat_namescat.csv")) as t:
+            assert list(csv.reader(t)) == [["a", "b"], ["1", "x"], ["2", "y"]]
+        with open(os.path.join(self._data_dir, "dog_namesdog.csv")) as t:
+            assert list(csv.reader(t)) == [["a", "b"], ["3", "z"]]
+
 
 class TestCsvConvert(TestCsvTransform):
     def test_convert_header(self):


### PR DESCRIPTION
## Brief ##

Added group mode to CsvConcat.
It uses regex to group files by their naming conventions and merges them group-by-group.

## Points to Check ##
* Any unexpected impact
* The overall quality is trending positively

### Test ###
Confirmed

Pass ALL unit test.

### Review Limit ###
* `Write review limit on pull request title.`
