### PR TITLE
Deprecate src_filenames in CsvConcat

### DIFF
--- a/cliboa/scenario/transform/csv.py
+++ b/cliboa/scenario/transform/csv.py
@@ -31,7 +31,7 @@ from cliboa.adapter.file import File
 from cliboa.adapter.sqlite import SqliteAdapter
 from cliboa.scenario.transform.file import FileBaseTransform
 from cliboa.scenario.validator import EssentialParameters
-from cliboa.util.base import _BaseObject  # _warn_deprecated_args
+from cliboa.util.base import _BaseObject, _warn_deprecated  # _warn_deprecated_args
 from cliboa.util.exception import CliboaException, FileNotFound, InvalidCount, InvalidParameter
 from cliboa.util.string import StringUtil
 
@@ -578,6 +578,12 @@ class CsvConcat(FileBaseTransform):
         if self.args.src_pattern:
             files = self.get_src_files()
         else:
+            _warn_deprecated(
+                "CsvConcat.src_filenames",
+                end_version="3.0",
+                removal_version="4.0",
+                instead="src_pattern",
+            )
             files = []
             for file in self.args.src_filenames:
                 files.append(os.path.join(self.args.src_dir, file))

--- a/cliboa/scenario/transform/csv.py
+++ b/cliboa/scenario/transform/csv.py
@@ -579,10 +579,10 @@ class CsvConcat(FileBaseTransform):
             files = self.get_src_files()
         else:
             _warn_deprecated(
-                "CsvConcat.src_filenames",
-                end_version="3.0",
+                "CsvConcat.Arguments.src_filenames",
+                end_version="3.1",
                 removal_version="4.0",
-                instead="src_pattern",
+                instead="CsvConcat.Arguments.src_pattern",
             )
             files = []
             for file in self.args.src_filenames:

--- a/docs/modules/csv_concat.md
+++ b/docs/modules/csv_concat.md
@@ -8,8 +8,8 @@ You can concatenate **all** matched files into a single output (`mode: all`, def
 |Parameters|Explanation|Required|Default|Remarks|
 |----------|-----------|--------|-------|-------|
 |src_dir|Path of the directory which target files are placed.|Yes|None||
-|src_pattern|Regex which is to find target files.|Yes|None|Used as `fullmatch` against each file **name** (not the full path). With `mode: group`, the pattern must include at least one **capturing** group; see below.|
-|src_filenames|File names of source to concat.|No|None|Specify either `src_pattern` or `src_filenames`. Cannot be used with `mode: group`.|
+|src_pattern|Regex which is to find target files.|Conditional|None|Required unless `src_filenames` is specified (deprecated). Used as `fullmatch` against each file **name** (not the full path). With `mode: group`, the pattern must include at least one **capturing** group; see below.|
+|src_filenames|Deprecated since v3.0. Use `src_pattern` instead.|No|None|Will be removed in v4.0.|
 |dest_dir|Path of the directory which is for output files.|Yes|None|If a non-existent directory path is specified, the directory is automatically created.|
 |dest_name|Output file name.|Conditional|None|Required when `mode` is `all`. Must **not** be set when `mode` is `group` (output names come from `src_pattern`).|
 |mode|How inputs are combined.|No|`all`|`all`: merge every target file into one file named `dest_name`. `group`: split targets into groups that share the same derived output basename, then write one file per group.|
@@ -23,18 +23,16 @@ scenario:
   class: CsvConcat
   arguments:
     src_dir: /in
-    src_filenames:
-      - file1.csv
-      - file2.csv
+    src_pattern: 'file.*\.csv'
     dest_dir: /out
     dest_name: concat.csv
 
-Input: /in/test1.csv
+Input: /in/file1.csv
 id, name
 1, one
 2, two
 
-Input: /in/test2.csv
+Input: /in/file2.csv
 id, name
 3, three
 4, four

--- a/docs/modules/csv_concat.md
+++ b/docs/modules/csv_concat.md
@@ -9,7 +9,7 @@ You can concatenate **all** matched files into a single output (`mode: all`, def
 |----------|-----------|--------|-------|-------|
 |src_dir|Path of the directory which target files are placed.|Yes|None||
 |src_pattern|Regex which is to find target files.|Conditional|None|Required unless `src_filenames` is specified (deprecated). Used as `fullmatch` against each file **name** (not the full path). With `mode: group`, the pattern must include at least one **capturing** group; see below.|
-|src_filenames|Deprecated since v3.0. Use `src_pattern` instead.|No|None|Will be removed in v4.0.|
+|src_filenames|Deprecated since v3.1. Use `src_pattern` instead.|No|None|Will be removed in v4.0.|
 |dest_dir|Path of the directory which is for output files.|Yes|None|If a non-existent directory path is specified, the directory is automatically created.|
 |dest_name|Output file name.|Conditional|None|Required when `mode` is `all`. Must **not** be set when `mode` is `group` (output names come from `src_pattern`).|
 |mode|How inputs are combined.|No|`all`|`all`: merge every target file into one file named `dest_name`. `group`: split targets into groups that share the same derived output basename, then write one file per group.|

--- a/tests/scenario/transform/test_csv.py
+++ b/tests/scenario/transform/test_csv.py
@@ -1469,7 +1469,8 @@ class TestCsvConcat(TestCsvTransform):
                 "dest_name": "test.csv",
             }
         )
-        instance.execute()
+        with pytest.warns(DeprecationWarning, match="src_filenames"):
+            instance.execute()
 
         with open(os.path.join(self._data_dir, "test.csv")) as t:
             reader = csv.reader(t)
@@ -1601,7 +1602,8 @@ class TestCsvConcat(TestCsvTransform):
                 "dest_name": "test.csv",
             }
         )
-        instance.execute()
+        with pytest.warns(DeprecationWarning, match="src_filenames"):
+            instance.execute()
 
         with open(os.path.join(self._data_dir, "test.csv")) as t:
             reader = csv.reader(t)
@@ -1739,6 +1741,22 @@ class TestCsvConcat(TestCsvTransform):
             assert list(csv.reader(t)) == [["a", "b"], ["1", "x"], ["2", "y"]]
         with open(os.path.join(self._data_dir, "dog_namesdog.csv")) as t:
             assert list(csv.reader(t)) == [["a", "b"], ["3", "z"]]
+
+    def test_execute_src_filenames_emits_deprecation_warning(self):
+        self._create_csv([["key", "data"], ["c1", "001"]], fname="test1.csv")
+        self._create_csv([["key", "data"], ["c2", "002"]], fname="test2.csv")
+
+        instance = CsvConcat()
+        instance._set_arguments(
+            {
+                "src_dir": self._data_dir,
+                "src_filenames": ["test1.csv", "test2.csv"],
+                "dest_dir": self._data_dir,
+                "dest_name": "out.csv",
+            }
+        )
+        with pytest.warns(DeprecationWarning, match="src_filenames"):
+            instance.execute()
 
 
 class TestCsvConvert(TestCsvTransform):


### PR DESCRIPTION
Brief               
                                                                                                                                  
  Deprecate src_filenames parameter in CsvConcat to pave the way for its removal in v4.0.                                                  
                                                                                                                                           
  src_filenames is redundant since src_pattern already covers file selection, is unique to CsvConcat (inconsistent with the rest of the    
  ecosystem), and adds unnecessary complexity to the validation logic. When src_filenames is used, a DeprecationWarning is now emitted     
  pointing users to src_pattern instead.                                                                                                   
                                                                                                                                         
  Points to Check

  - DeprecationWarning is emitted via the existing _warn_deprecated utility, consistent with other deprecations in the codebase            
  (ObjectStore, cliboa.util.helper, etc.)
  - Backward compatibility is fully maintained — src_filenames still works, no existing behaviour is broken                                
  - Documentation updated: parameter table marks src_filenames as deprecated, example replaced with src_pattern equivalent                 
                                                                                                                                           
  Test                                                                                                                                     
                                                                                                                                           
  Confirmed                                                                                                                              

  - Existing test_execute_ok1 and test_execute_ok5 updated to assert DeprecationWarning is emitted                                         
  - New dedicated test test_execute_src_filenames_emits_deprecation_warning added to explicitly verify the warning fires
  - All 11 TestCsvConcat tests pass                                                                                                        
                                                                                                                                         
  Review Limit                                                                                                                             
                                                                                                                                         
  - [Deprecate src_filenames in CsvConcat

Fixes #666   