### PR TITLE
feat: improve CsvConcat logging by removing misleading warning

### DIFF
--- a/cliboa/scenario/transform/csv.py
+++ b/cliboa/scenario/transform/csv.py
@@ -591,9 +591,10 @@ class CsvConcat(FileBaseTransform):
             for file in self.args.src_filenames:
                 files.append(os.path.join(self.args.src_dir, file))
 
-        self.logger.info(f"{len(files)} input files are found.")
         if len(files) == 0:
             raise FileNotFound("No files are found.")
+
+        self.logger.info(f"{len(files)} input files are found.")
 
         # Create output headers to conform to the concat specification.
         if self.args.mode == "all":

--- a/cliboa/scenario/transform/csv.py
+++ b/cliboa/scenario/transform/csv.py
@@ -591,10 +591,9 @@ class CsvConcat(FileBaseTransform):
             for file in self.args.src_filenames:
                 files.append(os.path.join(self.args.src_dir, file))
 
+        self.logger.info(f"{len(files)} input files are found.")
         if len(files) == 0:
             raise FileNotFound("No files are found.")
-        elif len(files) == 1:
-            self.logger.warning("Two or more input files are required.")
 
         # Create output headers to conform to the concat specification.
         if self.args.mode == "all":


### PR DESCRIPTION
Fixes #673.

This PR improves the logging in `CsvConcat` by removing the misleading warning "Two or more input files are required" when only one file is provided. Since the process continues successfully with one file, a warning was inappropriate. An INFO level log has been added to explicitly state the number of input files being processed.