### PR TITLE
ci: keep stale label on update to avoid stale timer reset

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -24,6 +24,7 @@ jobs:
           close-pr-message: 'This pull request was closed automatically.'
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
+          remove-stale-when-updated: false
           exempt-pr-labels: 'no-stale'
           exempt-issue-labels: 'no-stale'
           operations-per-run: 100


### PR DESCRIPTION
## Brief ##

Set `remove-stale-when-updated: false` so a stale-labeled issue/PR isn't reset to the 365-day track by an accidental update (e.g. relabeling).
The stale label persists once applied, while manual stale-labeling still closes after days-before-close.

## Review Exemption

This PR will be merged by myself under the **3-5. Review Process Exception** after all CI checks pass.
