### PR TITLE
feat(core): add strict validation for with_vars conflicts(Fixes #688)

### DIFF
--- a/cliboa/core/model.py
+++ b/cliboa/core/model.py
@@ -54,8 +54,14 @@ class _BaseWithVars(BaseModel):
 
     def _merge_static_vars(self, data: dict[str, str]) -> None:
         """
-        merge calc result (not overwrite)
+        merge calc result (overwrite is strictly prohibited)
         """
+        for key in data.keys():
+            if key in self._with_static_vars:
+                raise InvalidFormat(
+                    f"Scope conflict in 'with_vars': '{key}' is defined "
+                    "in both global and step levels. It cannot be overwritten."
+                )
         self._with_static_vars = data | self._with_static_vars
 
 
@@ -240,6 +246,12 @@ class ScenarioModel(_BaseWithVars):
         Merge common scenario settings.
         """
         self.parallel_config.merge(cmn.parallel_config)
+
+        for key in cmn.with_vars.keys():
+            if key in self.with_vars:
+                raise InvalidFormat(
+                    f"Global 'with_vars' conflict: '{key}' is defined in multiple files."
+                )
         self.with_vars = cmn.with_vars | self.with_vars
 
         for step in self.scenario:
@@ -260,6 +272,13 @@ class ScenarioModel(_BaseWithVars):
                 continue
 
             step.arguments = cmn_step.arguments | step.arguments
+
+            for key in cmn_step.with_vars.keys():
+                if key in step.with_vars:
+                    raise InvalidFormat(
+                        f"Step 'with_vars' conflict in class '{step.class_name}': "
+                        f"'{key}' is defined in multiple files."
+                    )
             step.with_vars = cmn_step.with_vars | step.with_vars
             return
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -26,12 +26,21 @@ class TestBaseWithVars:
         assert model._with_static_vars == {"today": today_str}
 
     def test_merge_static_vars_ok(self):
-        # Test merging static vars
+        # Test merging static vars without overlap
         model = _BaseWithVars()
-        model._with_static_vars = {"a": "1", "b": "2"}
-        model._merge_static_vars({"b": "override", "c": "3"})
-        # Existing keys in _with_static_vars should take precedence
+        model._with_static_vars = {"a": "1"}
+        model._merge_static_vars({"b": "2", "c": "3"})
+        # Should merge safely when there are no conflicting keys
         assert model._with_static_vars == {"b": "2", "c": "3", "a": "1"}
+
+    def test_merge_static_vars_conflict_ng(self):
+        # Test that overlapping static vars raise InvalidFormat
+        model = _BaseWithVars()
+        model._with_static_vars = {"overlap_var": "1"}
+        with pytest.raises(InvalidFormat) as exc_info:
+            model._merge_static_vars({"overlap_var": "override", "c": "3"})
+        assert "Scope conflict in 'with_vars'" in str(exc_info.value)
+        assert "overlap_var" in str(exc_info.value)
 
 
 class TestStepModel:
@@ -256,7 +265,7 @@ class TestScenarioModel:
         assert m.is_readable_as_common() is False
 
     def test_merge_ok(self):
-        # Test merging common scenario settings
+        # Test merging common scenario settings without conflicts
         scenario_data = {
             "scenario": [
                 {"step": "s1", "class": "ClassA", "arguments": {"arg1": "step_val"}},
@@ -273,7 +282,7 @@ class TestScenarioModel:
                     "arguments": {"arg1": "cmn_val", "arg2": "cmn_val2"},
                 },
             ],
-            "with_vars": {"common_var": "val2", "scenario_var": "val_cmn"},
+            "with_vars": {"common_var": "val2"},
             "parallel_config": {"multi_process_count": 4, "force_continue": None},
         }
 
@@ -286,7 +295,7 @@ class TestScenarioModel:
         assert model.parallel_config.force_continue is True  # Original value
         assert model.parallel_config.multi_process_count == 4  # Merged value
 
-        # Test with_vars merge (scenario's 'scenario_var' overrides common's)
+        # Test with_vars merge
         assert model.with_vars == {"common_var": "val2", "scenario_var": "val1"}
 
         # Test step arguments merge (step's 'arg1' overrides common's)
@@ -295,6 +304,43 @@ class TestScenarioModel:
         assert isinstance(step1, StepModel)
         assert step1.arguments == {"arg1": "step_val", "arg2": "cmn_val2"}
         assert step2.arguments == {}
+
+    def test_merge_global_with_vars_conflict_ng(self):
+        # Test that global with_vars overlap raises InvalidFormat
+        scenario_data = {
+            "scenario": [{"step": "s1", "class": "ClassA"}],
+            "with_vars": {"shared_var": "val1"},
+        }
+        common_data = {
+            "scenario": [{"step": "c1", "class": "ClassA"}],
+            "with_vars": {"shared_var": "val2"},
+        }
+        model = ScenarioModel.model_validate(scenario_data)
+        common = ScenarioModel.model_validate(common_data)
+
+        with pytest.raises(InvalidFormat) as exc_info:
+            model.merge(common)
+        assert "Global 'with_vars' conflict: 'shared_var'" in str(exc_info.value)
+
+    def test_merge_step_with_vars_conflict_ng(self):
+        # Test that step-level with_vars overlap raises InvalidFormat
+        scenario_data = {
+            "scenario": [
+                {"step": "s1", "class": "ClassA", "with_vars": {"shared_step_var": "val1"}}
+            ]
+        }
+        common_data = {
+            "scenario": [
+                {"step": "c1", "class": "ClassA", "with_vars": {"shared_step_var": "val2"}}
+            ]
+        }
+        model = ScenarioModel.model_validate(scenario_data)
+        common = ScenarioModel.model_validate(common_data)
+
+        with pytest.raises(InvalidFormat) as exc_info:
+            model.merge(common)
+        assert "Step 'with_vars' conflict in class 'ClassA'" in str(exc_info.value)
+        assert "shared_step_var" in str(exc_info.value)
 
     def test_setup_ok(self):
         # Test the full setup process


### PR DESCRIPTION
## Brief ##
Fixes https://github.com/BrainPad/cliboa/issues/688
This PR introduces a strict validation (fail-fast mechanism) when merging `with_vars` to prevent silent overwrites. 

Previously, if the same `with_vars` key was defined in multiple places (e.g., across multiple common files passed to `ScenarioManager`, or between global and step scopes), the framework silently overwrote the value. This PR updates `ScenarioModel` and `_BaseWithVars` to explicitly raise an `InvalidFormat` exception whenever a `with_vars` conflict is detected. 

*Note: The shallow-merge behavior for step `arguments` remains unchanged.*

## Points to Check ##
* Raised `InvalidFormat` in `_BaseWithVars._merge_static_vars` when there is a scope conflict between global and step levels.
* Raised `InvalidFormat` in `ScenarioModel.merge` when there is a global `with_vars` conflict across multiple files.
* Raised `InvalidFormat` in `ScenarioModel._merge_step` when there is a step-level `with_vars` conflict across multiple files.

### Test ###
Confirmed

Updated `test_model.py` to cover both normal scenarios (successful merges without overlaps) and abnormal scenarios (triggering `InvalidFormat` on `with_vars` conflicts). All tests and `lint.sh` checks (including Black, isort, and flake8) passed successfully.

### Review Limit ###
* Around 06/30